### PR TITLE
the project and regions are not parsed properly, both entries end up …

### DIFF
--- a/examples/subnet/README.md
+++ b/examples/subnet/README.md
@@ -1,15 +1,19 @@
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_file_path | Service account json auth path | string | - | yes |
-| group_email | Email for group to receive roles (ex. group@example.com) | string | - | yes |
-| sa_email | Email for Service Account to receive roles (Ex. default-sa@example-project-id.iam.gserviceaccount.com) | string | - | yes |
-| subnet_one | First full subnet id to add the IAM policies/bindings | string | - | yes |
-| subnet_two | Second full subnet id to add the IAM policies/bindings | string | - | yes |
-| user_email | Email for group to receive roles (Ex. user@example.com) | string | - | yes |
+| credentials\_file\_path | Service account json auth path | string | - | yes |
+| group\_email | Email for group to receive roles (ex. group@example.com) | string | - | yes |
+| project | The project where the subnet resides | string | - | yes |
+| region | The region where the subnet resides | string | - | yes |
+| sa\_email | Email for Service Account to receive roles (Ex. default-sa@example-project-id.iam.gserviceaccount.com) | string | - | yes |
+| subnet\_one | First subnet id to add the IAM policies/bindings | string | - | yes |
+| subnet\_two | Second subnet id to add the IAM policies/bindings | string | - | yes |
+| user\_email | Email for group to receive roles (Ex. user@example.com) | string | - | yes |
 
 [^]: (autogen_docs_end)
+
+## Caveats
+The module expects the subnets to be provided fully qualified.  (ex: `projects/<project_id>/regions/<region>/subnetworks/<subnet_name>`)  This example takes your inputted project, region and subnets to form the fully qualified subnet ids.

--- a/examples/subnet/main.tf
+++ b/examples/subnet/main.tf
@@ -16,6 +16,8 @@
 
 locals {
   credentials_file_path = "${var.credentials_file_path}"
+  subnet_one_full = "${format ("projects/%s/regions/%s/subnetworks/%s", var.project, var.region, var.subnet_one)}"
+  subnet_two_full = "${format ("projects/%s/regions/%s/subnetworks/%s", var.project, var.region, var.subnet_one)}"
 }
 
 /******************************************
@@ -31,7 +33,8 @@ provider "google" {
 module "subnet_iam_binding" {
   source = "../../"
 
-  subnets = ["${var.subnet_one}", "${var.subnet_two}"]
+
+  subnets = ["${local.subnet_one_full}", "${local.subnet_two_full}"]
 
   mode = "authoritative"
 

--- a/examples/subnet/main.tf
+++ b/examples/subnet/main.tf
@@ -16,8 +16,8 @@
 
 locals {
   credentials_file_path = "${var.credentials_file_path}"
-  subnet_one_full = "${format ("projects/%s/regions/%s/subnetworks/%s", var.project, var.region, var.subnet_one)}"
-  subnet_two_full = "${format ("projects/%s/regions/%s/subnetworks/%s", var.project, var.region, var.subnet_one)}"
+  subnet_one_full = "${format("projects/%s/regions/%s/subnetworks/%s", var.project, var.region, var.subnet_one)}"
+  subnet_two_full = "${format("projects/%s/regions/%s/subnetworks/%s", var.project, var.region, var.subnet_one)}"
 }
 
 /******************************************
@@ -32,7 +32,6 @@ provider "google" {
  *****************************************/
 module "subnet_iam_binding" {
   source = "../../"
-
 
   subnets = ["${local.subnet_one_full}", "${local.subnet_two_full}"]
 

--- a/examples/subnet/variables.tf
+++ b/examples/subnet/variables.tf
@@ -18,6 +18,14 @@ variable "credentials_file_path" {
   description = "Service account json auth path"
 }
 
+variable "project" {
+  description = "The project where the subnet resides"
+}
+
+variable "region" {
+  description = "The region where the subnet resides"
+}
+
 variable "group_email" {
   description = "Email for group to receive roles (ex. group@example.com)"
 }
@@ -34,9 +42,9 @@ variable "user_email" {
   Subnet_iam_binding variables
  *****************************************/
 variable "subnet_one" {
-  description = "First full subnet id to add the IAM policies/bindings"
+  description = "First subnet id to add the IAM policies/bindings"
 }
 
 variable "subnet_two" {
-  description = "Second full subnet id to add the IAM policies/bindings"
+  description = "Second subnet id to add the IAM policies/bindings"
 }

--- a/subnets_iam.tf
+++ b/subnets_iam.tf
@@ -21,7 +21,8 @@ resource "google_compute_subnetwork_iam_binding" "subnet_iam_authoritative" {
   count = "${local.subnets_authoritative_iam ? length(local.bindings_array) : 0}"
 
   subnetwork = "${element(split("/", element(split(" ", local.bindings_array[count.index]), 0)), 5)}"
-  project    = "${local.resources_project}"
+  region     = "${element(split("/", element(split(" ", local.bindings_array[count.index]), 0)), 3)}"
+  project    = "${element(split("/", element(split(" ", local.bindings_array[count.index]), 0)), 1)}"
   role       = "${element(split(" ", local.bindings_array[count.index]), 1)}"
 
   members = [
@@ -36,7 +37,8 @@ resource "google_compute_subnetwork_iam_member" "subnet_iam_additive" {
   count = "${local.subnets_additive_iam ? length(local.bindings_array) : 0}"
 
   subnetwork = "${element(split("/", element(split(" ", local.bindings_array[count.index]), 0)), 5)}"
-  project    = "${local.resources_project}"
+  region     = "${element(split("/", element(split(" ", local.bindings_array[count.index]), 0)), 3)}"
+  project    = "${element(split("/", element(split(" ", local.bindings_array[count.index]), 0)), 1)}"
   member     = "${element(split(" ", local.bindings_array[count.index]), 1)}"
   role       = "${element(split(" ", local.bindings_array[count.index]), 2)}"
 }

--- a/subnets_iam.tf
+++ b/subnets_iam.tf
@@ -21,8 +21,7 @@ resource "google_compute_subnetwork_iam_binding" "subnet_iam_authoritative" {
   count = "${local.subnets_authoritative_iam ? length(local.bindings_array) : 0}"
 
   subnetwork = "${element(split("/", element(split(" ", local.bindings_array[count.index]), 0)), 5)}"
-  region     = "${element(split("/", element(split(" ", local.bindings_array[count.index]), 0)), 3)}"
-  project    = "${element(split("/", element(split(" ", local.bindings_array[count.index]), 0)), 1)}"
+  project    = "${local.resources_project}"
   role       = "${element(split(" ", local.bindings_array[count.index]), 1)}"
 
   members = [
@@ -37,8 +36,7 @@ resource "google_compute_subnetwork_iam_member" "subnet_iam_additive" {
   count = "${local.subnets_additive_iam ? length(local.bindings_array) : 0}"
 
   subnetwork = "${element(split("/", element(split(" ", local.bindings_array[count.index]), 0)), 5)}"
-  region     = "${element(split("/", element(split(" ", local.bindings_array[count.index]), 0)), 3)}"
-  project    = "${element(split("/", element(split(" ", local.bindings_array[count.index]), 0)), 1)}"
+  project    = "${local.resources_project}"
   member     = "${element(split(" ", local.bindings_array[count.index]), 1)}"
   role       = "${element(split(" ", local.bindings_array[count.index]), 2)}"
 }


### PR DESCRIPTION
ex:
```
   + module.subnet_iam_binding.google_compute_subnetwork_iam_member.subnet_iam_additive
      id:         <computed>
      etag:       <computed>
      member:     "serviceAccount:service-158105332103@container-engine-robot.iam.gserviceaccount.com"
      project:    "gke-subnet"
      region:     "gke-subnet"
      role:       "roles/compute.networkUser"
      subnetwork: "gke-subnet"
```

Running the example listed, requires the provider to specify `project` and `region`

Does that mean the `main.tf` in the module should handle region?