### PR TITLE
Add simple module to enable a given service account to write to Stackdriver

### DIFF
--- a/examples/stackdriver_agent_roles/CLOUDSHELL_INSTRUCTIONS.txt
+++ b/examples/stackdriver_agent_roles/CLOUDSHELL_INSTRUCTIONS.txt
@@ -1,0 +1,1 @@
+To set up a service account to write to Stackdriver, follow the above instructions to set your project ID, run `terraform init && terraform apply`, and enter the email address of the service account.

--- a/examples/stackdriver_agent_roles/CLOUDSHELL_INSTRUCTIONS.txt
+++ b/examples/stackdriver_agent_roles/CLOUDSHELL_INSTRUCTIONS.txt
@@ -1,1 +1,0 @@
-To set up a service account to write to Stackdriver, follow the above instructions to set your project ID, run `terraform init && terraform apply`, and enter the email address of the service account.

--- a/examples/stackdriver_agent_roles/CLOUDSHELL_TUTORIAL.md
+++ b/examples/stackdriver_agent_roles/CLOUDSHELL_TUTORIAL.md
@@ -1,0 +1,21 @@
+# Stackdriver Agent Roles for Service Account
+
+### Configuration
+
+### Set your Project ID
+
+In the Shell below, run `gcloud config set <PROJECT_ID>`, where `<PROJECT_ID>` is the GCP project in which you wish to grant roles to the service account.
+
+### Initialize Terraform
+
+In the Shell, run `terraform init` to initialize `terraform` and download necessary support files.
+
+## Applying Changes
+
+### Run Terraform
+
+In the Shell, run `terraform apply`. When prompted, enter the email address for the service account that you'd like to grant these roles to. Review the changes that `terraform` would like to apply, then type `yes` to confirm.
+
+### You're Done!
+
+If `terraform` completes without error, the IAM roles `roles/logging/logWriter` and `roles/monitoring.metricWriter` have been applied to the service account you specified.

--- a/examples/stackdriver_agent_roles/CLOUDSHELL_TUTORIAL.md
+++ b/examples/stackdriver_agent_roles/CLOUDSHELL_TUTORIAL.md
@@ -4,13 +4,11 @@
 
 ### Set your Project ID
 
-In the Shell below, run `gcloud config set <PROJECT_ID>`, where `<PROJECT_ID>` is the GCP project in which you wish to grant roles to the service account.
+In the Shell below, run `gcloud config set project <PROJECT_ID>`, where `<PROJECT_ID>` is the GCP project in which you wish to grant roles to the service account.
 
 ### Initialize Terraform
 
 In the Shell, run `terraform init` to initialize `terraform` and download necessary support files.
-
-## Applying Changes
 
 ### Run Terraform
 
@@ -18,4 +16,4 @@ In the Shell, run `terraform apply`. When prompted, enter the email address for 
 
 ### You're Done!
 
-If `terraform` completes without error, the IAM roles `roles/logging/logWriter` and `roles/monitoring.metricWriter` have been applied to the service account you specified.
+If `terraform` completes without error, the IAM roles `roles/logging.logWriter` and `roles/monitoring.metricWriter` have been applied to the service account you specified.

--- a/examples/stackdriver_agent_roles/README.md
+++ b/examples/stackdriver_agent_roles/README.md
@@ -4,11 +4,10 @@ Applies the roles necessary to write metrics and logs to Stackdriver to a given 
 
 ## Quick Start
 
-[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_image=gcr.io/graphite-cloud-shell-images/terraform:latest&cloudshell_git_repo=https://github.com/terraform-google-modules/terraform-google-iam.git&cloudshell_working_dir=examples/stackdriver_agent_roles&cloudshell_print=CLOUDSHELL_INSTRUCTIONS.txt)
+[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_image=gcr.io/graphite-cloud-shell-images/terraform:latest&cloudshell_git_repo=https://github.com/terraform-google-modules/terraform-google-iam.git&cloudshell_working_dir=examples/stackdriver_agent_roles&cloudshell_tutorial=CLOUDSHELL_TUTORIAL.md)
 
 1. Use the above link to open a Cloud Shell
-2. In the Cloud Shell, run `gcloud config set project <PROJECT_ID>`, where `<PROJECT_ID>` is the GCP project in which you wish to grant roles
-3. Run `terraform init && terraform apply` and fill in the relevant service account email when prompted.
+2. Follow the tutorial presented in Cloud Shell (see also [CLOUDSHELL_TUTORIAL.md](./CLOUDSHELL_TUTORIAL.md)).
 
 [^]: (autogen_docs_start)
 

--- a/examples/stackdriver_agent_roles/README.md
+++ b/examples/stackdriver_agent_roles/README.md
@@ -1,0 +1,22 @@
+# Stackdriver Agent Roles
+
+Applies the roles necessary to write metrics and logs to Stackdriver to a given service account.
+
+## Quick Start
+
+[![Open in Cloud Shell](http://www.gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_image=gcr.io/graphite-cloud-shell-images/terraform:latest&cloudshell_git_repo=https://github.com/terraform-google-modules/terraform-google-iam.git&cloudshell_working_dir=examples/stackdriver_agent_roles&cloudshell_print=CLOUDSHELL_INSTRUCTIONS.txt)
+
+1. Use the above link to open a Cloud Shell
+2. In the Cloud Shell, run `gcloud config set project <PROJECT_ID>`, where `<PROJECT_ID>` is the GCP project in which you wish to grant roles
+3. Run `terraform init && terraform apply` and fill in the relevant service account email when prompted.
+
+[^]: (autogen_docs_start)
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| service_account_email | The service account email to enable Stackdriver agent roles on | string | - | yes |
+
+[^]: (autogen_docs_end)

--- a/examples/stackdriver_agent_roles/main.tf
+++ b/examples/stackdriver_agent_roles/main.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_project_iam_member" "monitoring-log_writer" {
+  role   = "roles/logging.logWriter"
+  member = "serviceAccount:${var.service_account_email}"
+}
+
+resource "google_project_iam_member" "monitoring-metric_writer" {
+  role   = "roles/monitoring.metricWriter"
+  member = "serviceAccount:${var.service_account_email}"
+}

--- a/examples/stackdriver_agent_roles/variables.tf
+++ b/examples/stackdriver_agent_roles/variables.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "service_account_email" {
+  description = "The service account email to enable Stackdriver agent roles on"
+}


### PR DESCRIPTION
Introduces a simple module that adds roles necessary for a service account to write metrics and logs to Stackdriver. Does so using `google_project_iam_member` resources directly, to avoid needing to specify the project ID explicitly, thus enabling a smoother Cloud Shell experience.

Note that the Cloud Shell URL in the example's README.md points to the master branch. For testing purposes, please use the following URL: https://console.cloud.google.com/cloudshell/editor?cloudshell_image=gcr.io/graphite-cloud-shell-images/terraform:latest&cloudshell_git_repo=https://github.com/terraform-google-modules/terraform-google-iam.git&cloudshell_working_dir=examples/stackdriver_agent_roles&cloudshell_tutorial=CLOUDSHELL_TUTORIAL.md&cloudshell_git_branch=feature/stackdriver-agent-role-module