### PR TITLE
Remove double folders/ path

### DIFF
--- a/folders_iam.tf
+++ b/folders_iam.tf
@@ -20,7 +20,7 @@
 resource "google_folder_iam_binding" "folder_iam_authoritative" {
   count = "${local.folders_authoritative_iam ? length(local.bindings_array) : 0}"
 
-  folder = "folders/${element(split(" ", local.bindings_array[count.index]), 0)}"
+  folder = "${element(split(" ", local.bindings_array[count.index]), 0)}"
   role   = "${element(split(" ", local.bindings_array[count.index]), 1)}"
 
   members = [
@@ -34,7 +34,7 @@ resource "google_folder_iam_binding" "folder_iam_authoritative" {
 resource "google_folder_iam_member" "folder_iam_additive" {
   count = "${local.folders_additive_iam ? length(local.bindings_array) : 0}"
 
-  folder = "folders/${element(split(" ", local.bindings_array[count.index]), 0)}"
+  folder = "${element(split(" ", local.bindings_array[count.index]), 0)}"
   member = "${element(split(" ", local.bindings_array[count.index]), 1)}"
   role   = "${element(split(" ", local.bindings_array[count.index]), 2)}"
 }

--- a/folders_iam.tf
+++ b/folders_iam.tf
@@ -20,7 +20,7 @@
 resource "google_folder_iam_binding" "folder_iam_authoritative" {
   count = "${local.folders_authoritative_iam ? length(local.bindings_array) : 0}"
 
-  folder = "${element(split(" ", local.bindings_array[count.index]), 0)}"
+  folder = "folders/${replace(element(split(" ", local.bindings_array[count.index]), 0), "folders/", "")}"
   role   = "${element(split(" ", local.bindings_array[count.index]), 1)}"
 
   members = [
@@ -34,7 +34,7 @@ resource "google_folder_iam_binding" "folder_iam_authoritative" {
 resource "google_folder_iam_member" "folder_iam_additive" {
   count = "${local.folders_additive_iam ? length(local.bindings_array) : 0}"
 
-  folder = "${element(split(" ", local.bindings_array[count.index]), 0)}"
+  folder = "folders/${replace(element(split(" ", local.bindings_array[count.index]), 0), "folders/", "")}"
   member = "${element(split(" ", local.bindings_array[count.index]), 1)}"
   role   = "${element(split(" ", local.bindings_array[count.index]), 2)}"
 }


### PR DESCRIPTION
When defining folders within the IAM policy definition, `terraform apply` fails to apply due to  `folders/` being prepended:-

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

-/+ module.XXXX-deployment-manager-iam.google_folder_iam_member.folder_iam_additive[0] (new resource required)
      id:     "folders/722920872132/roles/resourcemanager.projectCreator/serviceAccount:253094198234@cloudservices.gserviceaccount.com" => <computed> (forces new resource)
      etag:   "BwWJsKJoqbU=" => <computed>
      folder: "folders/722920872132" => "folders/folders/722920872132" (forces new resource)
      member: "serviceAccount:253094198234@cloudservices.gserviceaccount.com" => "serviceAccount:253094198234@cloudservices.gserviceaccount.com"
      role:   "roles/resourcemanager.projectCreator" => "roles/resourcemanager.projectCreator"

-/+ module.XXXX-deployment-manager-iam.google_folder_iam_member.folder_iam_additive[1] (new resource required)
      id:     "folders/565091952623/roles/resourcemanager.projectCreator/serviceAccount:253094198234@cloudservices.gserviceaccount.com" => <computed> (forces new resource)
      etag:   "BwWJsKJqCfY=" => <computed>
      folder: "folders/565091952623" => "folders/folders/565091952623" (forces new resource)
      member: "serviceAccount:253094198234@cloudservices.gserviceaccount.com" => "serviceAccount:253094198234@cloudservices.gserviceaccount.com"
      role:   "roles/resourcemanager.projectCreator" => "roles/resourcemanager.projectCreator"


Plan: 2 to add, 0 to change, 2 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: 

```

The snippet I was testing with:-

```
resource "google_folder" "XXXX_apps" {
  display_name = "${upper(var.project_name)}-${upper(var.continent)}-APPS"
  parent       = "folders/${var.folder_id}"
}

resource "google_folder" "XXXX_tenants" {
  display_name = "${upper(var.project_name)}-${upper(var.continent)}-TENANTS"
  parent       = "folders/${var.folder_id}"
}

module "XXXX-deployment-manager-iam" {
  source   = "git::https://github.com/terraform-google-modules/terraform-google-iam.git"
  mode     = "additive"
  folders = ["${data.terraform_remote_state.XXXX.folder_apps}", "${data.terraform_remote_state.XXXX.folder_tenants}"]

  bindings = {
    "roles/resourcemanager.projectCreator" = [
      "serviceAccount:${data.terraform_remote_state.projects.project_number}@cloudservices.gserviceaccount.com",
    ]
  }
}
```