### PR TITLE
Implements #28: Source credentials from environment variables

### DIFF
--- a/examples/folder/README.md
+++ b/examples/folder/README.md
@@ -4,7 +4,6 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials\_file\_path | Service account json auth path | string | n/a | yes |
 | folder\_one | The first folder ID to apply IAM bindings | string | n/a | yes |
 | folder\_two | The second folder ID to apply IAM bindings | string | n/a | yes |
 | group\_email | Email for group to receive roles (ex. group@example.com) | string | n/a | yes |

--- a/examples/folder/main.tf
+++ b/examples/folder/main.tf
@@ -14,20 +14,14 @@
  * limitations under the License.
  */
 
-locals {
-  credentials_file_path = "${var.credentials_file_path}"
-}
-
 /******************************************
   Provider configuration
  *****************************************/
 provider "google" {
-  credentials = "${file(local.credentials_file_path)}"
   version     = "~> 2.7"
 }
 
 provider "google-beta" {
-  credentials = "${file(local.credentials_file_path)}"
   version     = "~> 2.7"
 }
 

--- a/examples/folder/variables.tf
+++ b/examples/folder/variables.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-variable "credentials_file_path" {
-  description = "Service account json auth path"
-}
-
 variable "group_email" {
   description = "Email for group to receive roles (ex. group@example.com)"
 }

--- a/examples/kms_crypto_key/README.md
+++ b/examples/kms_crypto_key/README.md
@@ -5,7 +5,6 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_file_path | Service account json auth path | string | - | yes |
 | group_email | Email for group to receive roles (ex. group@example.com) | string | - | yes |
 | kms_crypto_key_one | First kms_cripto_key to add the IAM policies/bindings | string | - | yes |
 | kms_crypto_key_two | Second kms_cripto_key to add the IAM policies/bindings | string | - | yes |

--- a/examples/kms_crypto_key/main.tf
+++ b/examples/kms_crypto_key/main.tf
@@ -14,20 +14,14 @@
  * limitations under the License.
  */
 
-locals {
-  credentials_file_path = var.credentials_file_path
-}
-
 /******************************************
   Provider configuration
  *****************************************/
 provider "google" {
-  credentials = file(local.credentials_file_path)
   version     = "~> 2.7"
 }
 
 provider "google-beta" {
-  credentials = file(local.credentials_file_path)
   version     = "~> 2.7"
 }
 

--- a/examples/kms_crypto_key/variables.tf
+++ b/examples/kms_crypto_key/variables.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-variable "credentials_file_path" {
-  description = "Service account json auth path"
-}
-
 variable "group_email" {
   description = "Email for group to receive roles (ex. group@example.com)"
 }

--- a/examples/kms_key_ring/README.md
+++ b/examples/kms_key_ring/README.md
@@ -5,7 +5,6 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_file_path | Service account json auth path | string | - | yes |
 | group_email | Email for group to receive roles (ex. group@example.com) | string | - | yes |
 | kms_key_ring_one | First kms_ring to add the IAM policies/bindings | string | - | yes |
 | kms_key_ring_two | First kms_ring to add the IAM policies/bindings | string | - | yes |

--- a/examples/kms_key_ring/main.tf
+++ b/examples/kms_key_ring/main.tf
@@ -14,20 +14,14 @@
  * limitations under the License.
  */
 
-locals {
-  credentials_file_path = var.credentials_file_path
-}
-
 /******************************************
   Provider configuration
  *****************************************/
 provider "google" {
-  credentials = file(local.credentials_file_path)
   version     = "~> 2.7"
 }
 
 provider "google-beta" {
-  credentials = file(local.credentials_file_path)
   version     = "~> 2.7"
 }
 

--- a/examples/kms_key_ring/variables.tf
+++ b/examples/kms_key_ring/variables.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-variable "credentials_file_path" {
-  description = "Service account json auth path"
-}
-
 variable "group_email" {
   description = "Email for group to receive roles (ex. group@example.com)"
 }

--- a/examples/organization/README.md
+++ b/examples/organization/README.md
@@ -5,7 +5,6 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_file_path | Service account json auth path | string | - | yes |
 | group_email | Email for group to receive roles (ex. group@example.com) | string | - | yes |
 | organization_one | First organization to add the IAM policies/bindings | string | - | yes |
 | organization_two | Second organization to add the IAM policies/bindings | string | - | yes |

--- a/examples/organization/main.tf
+++ b/examples/organization/main.tf
@@ -14,20 +14,14 @@
  * limitations under the License.
  */
 
-locals {
-  credentials_file_path = var.credentials_file_path
-}
-
 /******************************************
   Provider configuration
  *****************************************/
 provider "google" {
-  credentials = file(local.credentials_file_path)
   version     = "~> 2.7"
 }
 
 provider "google-beta" {
-  credentials = file(local.credentials_file_path)
   version     = "~> 2.7"
 }
 

--- a/examples/organization/variables.tf
+++ b/examples/organization/variables.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-variable "credentials_file_path" {
-  description = "Service account json auth path"
-}
-
 variable "group_email" {
   description = "Email for group to receive roles (ex. group@example.com)"
 }

--- a/examples/project/README.md
+++ b/examples/project/README.md
@@ -5,7 +5,6 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_file_path | Service account json auth path | string | - | yes |
 | group_email | Email for group to receive roles (ex. group@example.com) | string | - | yes |
 | project_one | First project id to add the IAM policies/bindings | string | - | yes |
 | project_two | Second project id to add the IAM policies/bindings | string | - | yes |

--- a/examples/project/main.tf
+++ b/examples/project/main.tf
@@ -14,20 +14,14 @@
  * limitations under the License.
  */
 
-locals {
-  credentials_file_path = var.credentials_file_path
-}
-
 /******************************************
   Provider configuration
  *****************************************/
 provider "google" {
-  credentials = file(local.credentials_file_path)
   version     = "~> 2.7"
 }
 
 provider "google-beta" {
-  credentials = file(local.credentials_file_path)
   version     = "~> 2.7"
 }
 

--- a/examples/project/variables.tf
+++ b/examples/project/variables.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-variable "credentials_file_path" {
-  description = "Service account json auth path"
-}
-
 variable "group_email" {
   description = "Email for group to receive roles (ex. group@example.com)"
 }

--- a/examples/pubsub_subscription/README.md
+++ b/examples/pubsub_subscription/README.md
@@ -5,7 +5,6 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_file_path | Service account json auth path | string | - | yes |
 | group_email | Email for group to receive roles (ex. group@example.com) | string | - | yes |
 | pubsub_subscription_one | First pubsub subscription name to add the IAM policies/bindings | string | - | yes |
 | pubsub_subscription_project | Project id of the pub/sub subscription | string | - | yes |

--- a/examples/pubsub_subscription/main.tf
+++ b/examples/pubsub_subscription/main.tf
@@ -14,20 +14,14 @@
  * limitations under the License.
  */
 
-locals {
-  credentials_file_path = var.credentials_file_path
-}
-
 /******************************************
   Provider configuration
  *****************************************/
 provider "google" {
-  credentials = file(local.credentials_file_path)
   version     = "~> 2.7"
 }
 
 provider "google-beta" {
-  credentials = file(local.credentials_file_path)
   version     = "~> 2.7"
 }
 

--- a/examples/pubsub_subscription/variables.tf
+++ b/examples/pubsub_subscription/variables.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-variable "credentials_file_path" {
-  description = "Service account json auth path"
-}
-
 variable "group_email" {
   description = "Email for group to receive roles (ex. group@example.com)"
 }

--- a/examples/pubsub_topic/README.md
+++ b/examples/pubsub_topic/README.md
@@ -5,7 +5,6 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_file_path | Service account json auth path | string | - | yes |
 | group_email | Email for group to receive roles (ex. group@example.com) | string | - | yes |
 | pubsub_topic_one | First pubsub topic to add the IAM policies/bindings | string | - | yes |
 | pubsub_topic_project | Project id of the pub/sub topic | string | - | yes |

--- a/examples/pubsub_topic/main.tf
+++ b/examples/pubsub_topic/main.tf
@@ -14,20 +14,14 @@
  * limitations under the License.
  */
 
-locals {
-  credentials_file_path = var.credentials_file_path
-}
-
 /******************************************
   Provider configuration
  *****************************************/
 provider "google" {
-  credentials = file(local.credentials_file_path)
   version     = "~> 2.7"
 }
 
 provider "google-beta" {
-  credentials = file(local.credentials_file_path)
   version     = "~> 2.7"
 }
 

--- a/examples/pubsub_topic/variables.tf
+++ b/examples/pubsub_topic/variables.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-variable "credentials_file_path" {
-  description = "Service account json auth path"
-}
-
 variable "group_email" {
   description = "Email for group to receive roles (ex. group@example.com)"
 }

--- a/examples/service_account/README.md
+++ b/examples/service_account/README.md
@@ -4,7 +4,6 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials\_file\_path | Service account json auth path | string | n/a | yes |
 | group\_email | Email for group to receive roles (ex. group@example.com) | string | n/a | yes |
 | sa\_email | Email for Service Account to receive roles (Ex. default-sa@example-project-id.iam.gserviceaccount.com) | string | n/a | yes |
 | service\_account\_one | First service Account to add the IAM policies/bindings | string | n/a | yes |

--- a/examples/service_account/main.tf
+++ b/examples/service_account/main.tf
@@ -14,21 +14,15 @@
  * limitations under the License.
  */
 
-locals {
-  credentials_file_path = "${var.credentials_file_path}"
-}
-
 /******************************************
   Provider configuration
  *****************************************/
 provider "google" {
-  credentials = "${file(local.credentials_file_path)}"
   project     = "${var.service_account_project}"
   version     = "~> 2.7"
 }
 
 provider "google-beta" {
-  credentials = "${file(local.credentials_file_path)}"
   project     = "${var.service_account_project}"
   version     = "~> 2.7"
 }

--- a/examples/service_account/variables.tf
+++ b/examples/service_account/variables.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-variable "credentials_file_path" {
-  description = "Service account json auth path"
-}
-
 variable "group_email" {
   description = "Email for group to receive roles (ex. group@example.com)"
 }

--- a/examples/storage_bucket/README.md
+++ b/examples/storage_bucket/README.md
@@ -5,7 +5,6 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_file_path | Service account json auth path | string | - | yes |
 | group_email | Email for group to receive roles (ex. group@example.com) | string | - | yes |
 | sa_email | Email for Service Account to receive roles (Ex. default-sa@example-project-id.iam.gserviceaccount.com) | string | - | yes |
 | storage_bucket_one | First name of a GCS bucket to add the IAM policies/bindings | string | - | yes |

--- a/examples/storage_bucket/main.tf
+++ b/examples/storage_bucket/main.tf
@@ -14,20 +14,14 @@
  * limitations under the License.
  */
 
-locals {
-  credentials_file_path = var.credentials_file_path
-}
-
 /******************************************
   Provider configuration
  *****************************************/
 provider "google" {
-  credentials = file(local.credentials_file_path)
   version     = "~> 2.7"
 }
 
 provider "google-beta" {
-  credentials = file(local.credentials_file_path)
   version     = "~> 2.7"
 }
 

--- a/examples/storage_bucket/variables.tf
+++ b/examples/storage_bucket/variables.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-variable "credentials_file_path" {
-  description = "Service account json auth path"
-}
-
 variable "group_email" {
   description = "Email for group to receive roles (ex. group@example.com)"
 }

--- a/examples/subnet/README.md
+++ b/examples/subnet/README.md
@@ -4,7 +4,6 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials\_file\_path | Service account json auth path | string | - | yes |
 | group\_email | Email for group to receive roles (ex. group@example.com) | string | - | yes |
 | project | The project where the subnet resides | string | - | yes |
 | region | The region where the subnet resides | string | - | yes |

--- a/examples/subnet/main.tf
+++ b/examples/subnet/main.tf
@@ -15,7 +15,6 @@
  */
 
 locals {
-  credentials_file_path = var.credentials_file_path
   subnet_one_full = format(
     "projects/%s/regions/%s/subnetworks/%s",
     var.project,
@@ -34,12 +33,10 @@ locals {
   Provider configuration
  *****************************************/
 provider "google" {
-  credentials = file(local.credentials_file_path)
   version     = "~> 2.7"
 }
 
 provider "google-beta" {
-  credentials = file(local.credentials_file_path)
   version     = "~> 2.7"
 }
 

--- a/examples/subnet/variables.tf
+++ b/examples/subnet/variables.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-variable "credentials_file_path" {
-  description = "Service account json auth path"
-}
-
 variable "project" {
   description = "The project where the subnet resides"
 }

--- a/test/ci_integration.sh
+++ b/test/ci_integration.sh
@@ -38,6 +38,7 @@ setup_environment() {
 
   # Terraform variables
   export TF_VAR_project_id="$PROJECT_ID"
+  export TF_VAR_credentials_file_path="../../../credentials.json"
 }
 
 main() {

--- a/test/ci_integration.sh
+++ b/test/ci_integration.sh
@@ -38,7 +38,6 @@ setup_environment() {
 
   # Terraform variables
   export TF_VAR_project_id="$PROJECT_ID"
-  export TF_VAR_credentials_file_path="../../../credentials.json"
 }
 
 main() {

--- a/test/fixtures/full/main.tf
+++ b/test/fixtures/full/main.tf
@@ -52,12 +52,10 @@ locals {
 }
 
 provider "google" {
-  credentials = file(var.credentials_file_path)
   version     = "~> 2.7"
 }
 
 provider "google-beta" {
-  credentials = file(var.credentials_file_path)
   version     = "~> 2.7"
 }
 

--- a/test/fixtures/full/outputs.tf
+++ b/test/fixtures/full/outputs.tf
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-output "credentials_file_path" {
-  value       = "${path.module}/${var.credentials_file_path}"
-  description = "Path to google credentials file."
-}
-
 # Binding Roles
 
 output "basic_roles" {

--- a/test/fixtures/full/variables.tf
+++ b/test/fixtures/full/variables.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-variable "credentials_file_path" {
-  description = "Path to google credentials file."
-}
-
 variable "mode" {
   description = "Mode of IAM management ('authoritative' OR 'additive')."
 }

--- a/test/fixtures/full/variables.tf
+++ b/test/fixtures/full/variables.tf
@@ -15,7 +15,6 @@
  */
 
 variable "credentials_file_path" {
-  default     = "./credentials.json"
   description = "Path to google credentials file."
 }
 

--- a/test/integration/full/controls/gcloud.rb
+++ b/test/integration/full/controls/gcloud.rb
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = attribute('credentials_file_path')
-
 # Resource pairs (arrays of length = 2)
 folders          = attribute('folders')
 subnets          = attribute('subnets')

--- a/test/integration/full/controls/gcloud.rb
+++ b/test/integration/full/controls/gcloud.rb
@@ -14,13 +14,6 @@
 
 #ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = attribute('credentials_file_path')
 
-credentials_file_path = attribute('credentials_file_path')
-
-ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = File.absolute_path(
-  credentials_file_path,
-  File.join(__dir__, "../../../fixtures/full"))
-
-
 # Resource pairs (arrays of length = 2)
 folders          = attribute('folders')
 subnets          = attribute('subnets')

--- a/test/integration/full/controls/gcloud.rb
+++ b/test/integration/full/controls/gcloud.rb
@@ -12,7 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = attribute('credentials_file_path')
+#ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = attribute('credentials_file_path')
+
+credentials_file_path = attribute('credentials_file_path')
+
+ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = File.absolute_path(
+  credentials_file_path,
+  File.join(__dir__, "../../../fixtures/full"))
+
 
 # Resource pairs (arrays of length = 2)
 folders          = attribute('folders')

--- a/test/integration/full/inspec.yml
+++ b/test/integration/full/inspec.yml
@@ -14,9 +14,6 @@
 
 name: full
 attributes:
-  - name: credentials_file_path
-    required: true
-    type: string
   - name: folders
     required: true
     type: array


### PR DESCRIPTION
- removed hardcoded reference to credentials.json from tests
- updated relevant files (ci_integration.sh, test/integration/full/controls/gcloud.rb)
It seems that examples don't have hardcoded binding to the credentials file.