### PR TITLE
Delete escape characters to proper JSON processing

### DIFF
--- a/scripts/create_additive_authoritative_structures.sh
+++ b/scripts/create_additive_authoritative_structures.sh
@@ -150,7 +150,7 @@ function main {
   then
     build_authoritative
   fi
-  echo "$OUTPUT"| sed -e 's/.*/{\n  "data": "&/; s/$/"\n}/'
+  echo "$OUTPUT"| sed -e 's/.*/{"data": "&/; s/$/"}/'
 }
 
 main


### PR DESCRIPTION
This edit helps to rid of error with message:
Error: command "bash" produced invalid JSON: invalid character 'n' looking for beginning of object key string
Tested: error rises on Mac, disappears when edited as in PR