### PR TITLE
Use `for_each` instead of `count`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Terraform module makes it easier to non-destructively manage multiple IAM r
 
 ## Compatibility
 
-This module is meant for use with Terraform 0.12. If you haven't
+This module is meant for use with Terraform 0.12.6 and above. If you haven't
 [upgraded][terraform-0.12-upgrade] and need a Terraform 0.11.x-compatible
 version of this module, the last released version intended for Terraform 0.11.x
 is [1.1.1][v1.1.1].
@@ -223,7 +223,7 @@ The project has the following folders and files:
 
 ### Terraform plugins
 
-- [Terraform](https://www.terraform.io/downloads.html) 0.12
+- [Terraform](https://www.terraform.io/downloads.html) 0.12.6
 - [terraform-provider-google](https://github.com/terraform-providers/terraform-provider-google) 2.5
 - [terraform-provider-google-beta](https://github.com/terraform-providers/terraform-provider-google-beta) 2.5
 
@@ -280,7 +280,7 @@ In order to execute this module you must have a Service Account with an appropri
 
 ### Terraform
 
-Be sure you have the correct Terraform version (0.12), you can choose the binary here:
+Be sure you have the correct Terraform version (0.12.6), you can choose the binary here:
 - https://releases.hashicorp.com/terraform/
 
 ### Terraform plugins

--- a/examples/folder/versions.tf
+++ b/examples/folder/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.6"
 }

--- a/examples/kms_crypto_key/versions.tf
+++ b/examples/kms_crypto_key/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.6"
 }

--- a/examples/kms_key_ring/versions.tf
+++ b/examples/kms_key_ring/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.6"
 }

--- a/examples/organization/versions.tf
+++ b/examples/organization/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.6"
 }

--- a/examples/project/versions.tf
+++ b/examples/project/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.6"
 }

--- a/examples/pubsub_subscription/versions.tf
+++ b/examples/pubsub_subscription/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.6"
 }

--- a/examples/pubsub_topic/versions.tf
+++ b/examples/pubsub_topic/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.6"
 }

--- a/examples/service_account/versions.tf
+++ b/examples/service_account/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.6"
 }

--- a/examples/stackdriver_agent_roles/versions.tf
+++ b/examples/stackdriver_agent_roles/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.6"
 }

--- a/examples/storage_bucket/versions.tf
+++ b/examples/storage_bucket/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.6"
 }

--- a/examples/subnet/versions.tf
+++ b/examples/subnet/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.6"
 }

--- a/folders_iam.tf
+++ b/folders_iam.tf
@@ -18,35 +18,34 @@
   Folder IAM binding authoritative
  *****************************************/
 resource "google_folder_iam_binding" "folder_iam_authoritative" {
-  count = local.folders_authoritative_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.folders_authoritative_iam ? local.bindings_array : []) :
+    binding => {
+      folder  = "folders/${replace(element(split(" ", binding), 0), "folders/", "")}"
+      role    = element(split(" ", binding), 1)
+      members = compact(split(" ", element(split("=", binding), 1), ), )
+    }
+  }
 
-  folder = "folders/${replace(
-    element(split(" ", local.bindings_array[count.index]), 0),
-    "folders/",
-    "",
-  )}"
-  role = element(split(" ", local.bindings_array[count.index]), 1)
-
-  members = compact(
-    split(
-      " ",
-      element(split("=", local.bindings_array[count.index]), 1),
-    ),
-  )
+  folder  = each.value.folder
+  role    = each.value.role
+  members = each.value.members
 }
 
 /******************************************
   Folder IAM binding additive
  *****************************************/
 resource "google_folder_iam_member" "folder_iam_additive" {
-  count = local.folders_additive_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.folders_additive_iam ? local.bindings_array : []) :
+    binding => {
+      folder = "folders/${replace(element(split(" ", binding), 0), "folders/", "")}"
+      member = element(split(" ", binding), 1)
+      role   = element(split(" ", binding), 2)
+    }
+  }
 
-  folder = "folders/${replace(
-    element(split(" ", local.bindings_array[count.index]), 0),
-    "folders/",
-    "",
-  )}"
-  member = element(split(" ", local.bindings_array[count.index]), 1)
-  role   = element(split(" ", local.bindings_array[count.index]), 2)
+  folder = each.value.folder
+  member = each.value.member
+  role   = each.value.role
 }
-

--- a/kms_crypto_keys_iam.tf
+++ b/kms_crypto_keys_iam.tf
@@ -18,27 +18,34 @@
   Kms Crypto Key IAM binding authoritative
  *****************************************/
 resource "google_kms_crypto_key_iam_binding" "kms_crypto_key_iam_authoritative" {
-  count = local.kms_cryto_keys_authoritative_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.kms_crypto_keys_authoritative_iam ? local.bindings_array : []) :
+    binding => {
+      crypto_key_id = element(split(" ", binding), 0)
+      role          = element(split(" ", binding), 1)
+      members       = compact(split(" ", element(split("=", binding), 1)))
+    }
+  }
 
-  crypto_key_id = element(split(" ", local.bindings_array[count.index]), 0)
-  role          = element(split(" ", local.bindings_array[count.index]), 1)
-
-  members = compact(
-    split(
-      " ",
-      element(split("=", local.bindings_array[count.index]), 1),
-    ),
-  )
+  crypto_key_id = each.value.crypto_key_id
+  role          = each.value.role
+  members       = each.value.members
 }
 
 /******************************************
   Kms Crypto Key IAM binding additive
  *****************************************/
 resource "google_kms_crypto_key_iam_member" "kms_crypto_key_iam_additive" {
-  count = local.kms_cryto_keys_additive_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.kms_crypto_keys_additive_iam ? local.bindings_array : []) :
+    binding => {
+      crypto_key_id = element(split(" ", binding), 0)
+      member        = element(split(" ", binding), 1)
+      role          = element(split(" ", binding), 2)
+    }
+  }
 
-  crypto_key_id = element(split(" ", local.bindings_array[count.index]), 0)
-  member        = element(split(" ", local.bindings_array[count.index]), 1)
-  role          = element(split(" ", local.bindings_array[count.index]), 2)
+  crypto_key_id = each.value.crypto_key_id
+  member        = each.value.member
+  role          = each.value.role
 }
-

--- a/kms_key_rings_iam.tf
+++ b/kms_key_rings_iam.tf
@@ -18,27 +18,34 @@
   Kms Key Ring IAM binding authoritative
  *****************************************/
 resource "google_kms_key_ring_iam_binding" "kms_key_ring_iam_authoritative" {
-  count = local.kms_key_rings_authoritative_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.kms_key_rings_authoritative_iam ? local.bindings_array : []) :
+    binding => {
+      key_ring_id = element(split(" ", binding), 0)
+      role        = element(split(" ", binding), 1)
+      members     = compact(split(" ", element(split("=", binding), 1)))
+    }
+  }
 
-  key_ring_id = element(split(" ", local.bindings_array[count.index]), 0)
-  role        = element(split(" ", local.bindings_array[count.index]), 1)
-
-  members = compact(
-    split(
-      " ",
-      element(split("=", local.bindings_array[count.index]), 1),
-    ),
-  )
+  key_ring_id = each.value.key_ring_id
+  role        = each.value.role
+  members     = each.value.members
 }
 
 /******************************************
   Kms Key Ring IAM binding additive
  *****************************************/
 resource "google_kms_key_ring_iam_member" "kms_key_ring_iam_additive" {
-  count = local.kms_key_rings_additive_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.kms_key_rings_additive_iam ? local.bindings_array : []) :
+    binding => {
+      key_ring_id = element(split(" ", binding), 0)
+      member      = element(split(" ", binding), 1)
+      role        = element(split(" ", binding), 2)
+    }
+  }
 
-  key_ring_id = element(split(" ", local.bindings_array[count.index]), 0)
-  member      = element(split(" ", local.bindings_array[count.index]), 1)
-  role        = element(split(" ", local.bindings_array[count.index]), 2)
+  key_ring_id = each.value.key_ring_id
+  member      = each.value.member
+  role        = each.value.role
 }
-

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ locals {
   storage_buckets_authoritative_iam      = length(var.storage_buckets) > 0 && local.authoritative
   subnets_authoritative_iam              = length(var.subnets) > 0 && local.authoritative
   kms_key_rings_authoritative_iam        = length(var.kms_key_rings) > 0 && local.authoritative
-  kms_cryto_keys_authoritative_iam       = length(var.kms_crypto_keys) > 0 && local.authoritative
+  kms_crypto_keys_authoritative_iam      = length(var.kms_crypto_keys) > 0 && local.authoritative
   projects_additive_iam                  = length(var.projects) > 0 && local.additive
   folders_additive_iam                   = length(var.folders) > 0 && local.additive
   organizations_additive_iam             = length(var.organizations) > 0 && local.additive
@@ -39,7 +39,7 @@ locals {
   storage_buckets_additive_iam           = length(var.storage_buckets) > 0 && local.additive
   subnets_additive_iam                   = length(var.subnets) > 0 && local.additive
   kms_key_rings_additive_iam             = length(var.kms_key_rings) > 0 && local.additive
-  kms_cryto_keys_additive_iam            = length(var.kms_crypto_keys) > 0 && local.additive
+  kms_crypto_keys_additive_iam           = length(var.kms_crypto_keys) > 0 && local.additive
 
   # In order to retrieve the project from the provider, this variable takes it from a data source (google_project.project_from_provider) and avoid an error if the count for that resource is 0
   take_project_from_provider = var.project == "" && length(var.organizations) == 0 && length(var.folders) == 0 && length(var.projects) == 0 && length(var.storage_buckets) == 0 && length(var.kms_crypto_keys) == 0 && length(var.kms_key_rings) == 0 && length(var.subnets) == 0
@@ -73,7 +73,7 @@ locals {
     ),
   )
   service_accounts_passed = local.service_accounts_authoritative_iam || local.service_accounts_additive_iam ? "1" : "0"
-  kms_crypto_keys_passed  = local.kms_cryto_keys_additive_iam || local.kms_cryto_keys_authoritative_iam ? "1" : "0"
+  kms_crypto_keys_passed  = local.kms_crypto_keys_additive_iam || local.kms_crypto_keys_authoritative_iam ? "1" : "0"
   kms_key_rings_passed    = local.kms_key_rings_additive_iam || local.kms_key_rings_authoritative_iam ? "1" : "0"
 }
 

--- a/organizations_iam.tf
+++ b/organizations_iam.tf
@@ -18,27 +18,34 @@
   Organization IAM binding authoritative
  *****************************************/
 resource "google_organization_iam_binding" "organization_iam_authoritative" {
-  count = local.organizations_authoritative_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.organizations_authoritative_iam ? local.bindings_array : []) :
+    binding => {
+      org_id  = element(split(" ", binding), 0)
+      role    = element(split(" ", binding), 1)
+      members = compact(split(" ", element(split("=", binding), 1)))
+    }
+  }
 
-  org_id = element(split(" ", local.bindings_array[count.index]), 0)
-  role   = element(split(" ", local.bindings_array[count.index]), 1)
-
-  members = compact(
-    split(
-      " ",
-      element(split("=", local.bindings_array[count.index]), 1),
-    ),
-  )
+  org_id  = each.value.org_id
+  role    = each.value.role
+  members = each.value.members
 }
 
 /******************************************
   Organization IAM binding additive
  *****************************************/
 resource "google_organization_iam_member" "organization_iam_additive" {
-  count = local.organizations_additive_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.organizations_additive_iam ? local.bindings_array : []) :
+    binding => {
+      org_id = element(split(" ", binding), 0)
+      member = element(split(" ", binding), 1)
+      role   = element(split(" ", binding), 2)
+    }
+  }
 
-  org_id = element(split(" ", local.bindings_array[count.index]), 0)
-  member = element(split(" ", local.bindings_array[count.index]), 1)
-  role   = element(split(" ", local.bindings_array[count.index]), 2)
+  org_id = each.value.org_id
+  member = each.value.member
+  role   = each.value.role
 }
-

--- a/projects_iam.tf
+++ b/projects_iam.tf
@@ -18,27 +18,34 @@
   Project IAM binding authoritative
  *****************************************/
 resource "google_project_iam_binding" "project_iam_authoritative" {
-  count = local.projects_authoritative_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.projects_authoritative_iam ? local.bindings_array : []) :
+    binding => {
+      project = element(split(" ", binding), 0)
+      role    = element(split(" ", binding), 1)
+      members = compact(split(" ", element(split("=", binding), 1)))
+    }
+  }
 
-  project = element(split(" ", local.bindings_array[count.index]), 0)
-  role    = element(split(" ", local.bindings_array[count.index]), 1)
-
-  members = compact(
-    split(
-      " ",
-      element(split("=", local.bindings_array[count.index]), 1),
-    ),
-  )
+  project = each.value.project
+  role    = each.value.role
+  members = each.value.members
 }
 
 /******************************************
   Project IAM binding additive
  *****************************************/
 resource "google_project_iam_member" "project_iam_additive" {
-  count = local.projects_additive_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.projects_additive_iam ? local.bindings_array : []) :
+    binding => {
+      project = element(split(" ", binding), 0)
+      member  = element(split(" ", binding), 1)
+      role    = element(split(" ", binding), 2)
+    }
+  }
 
-  project = element(split(" ", local.bindings_array[count.index]), 0)
-  member  = element(split(" ", local.bindings_array[count.index]), 1)
-  role    = element(split(" ", local.bindings_array[count.index]), 2)
+  project = each.value.project
+  member  = each.value.member
+  role    = each.value.role
 }
-

--- a/pubsub_subscriptions_iam.tf
+++ b/pubsub_subscriptions_iam.tf
@@ -18,29 +18,36 @@
   Pubsub subscription IAM binding authoritative
  *****************************************/
 resource "google_pubsub_subscription_iam_binding" "pubsub_subscription_iam_authoritative" {
-  count = local.pubsub_subscriptions_authoritative_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.pubsub_subscriptions_authoritative_iam ? local.bindings_array : []) :
+    binding => {
+      subscription = element(split(" ", binding), 0)
+      role         = element(split(" ", binding), 1)
+      members      = compact(split(" ", element(split("=", binding), 1)))
+    }
+  }
 
-  subscription = element(split(" ", local.bindings_array[count.index]), 0)
   project      = local.resources_project
-  role         = element(split(" ", local.bindings_array[count.index]), 1)
-
-  members = compact(
-    split(
-      " ",
-      element(split("=", local.bindings_array[count.index]), 1),
-    ),
-  )
+  subscription = each.value.subscription
+  role         = each.value.role
+  members      = each.value.members
 }
 
 /******************************************
   Pubsub subscription IAM binding additive
  *****************************************/
 resource "google_pubsub_subscription_iam_member" "pubsub_subscription_iam_additive" {
-  count = local.pubsub_subscriptions_additive_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.pubsub_subscriptions_additive_iam ? local.bindings_array : []) :
+    binding => {
+      subscription = element(split(" ", binding), 0)
+      member       = element(split(" ", binding), 1)
+      role         = element(split(" ", binding), 2)
+    }
+  }
 
-  subscription = element(split(" ", local.bindings_array[count.index]), 0)
   project      = local.resources_project
-  member       = element(split(" ", local.bindings_array[count.index]), 1)
-  role         = element(split(" ", local.bindings_array[count.index]), 2)
+  subscription = each.value.subscription
+  member       = each.value.member
+  role         = each.value.role
 }
-

--- a/pubsub_topics_iam.tf
+++ b/pubsub_topics_iam.tf
@@ -18,29 +18,36 @@
   Pubsub topic IAM binding authoritative
  *****************************************/
 resource "google_pubsub_topic_iam_binding" "pubsub_topic_iam_authoritative" {
-  count = local.pubsub_topics_authoritative_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.pubsub_topics_authoritative_iam ? local.bindings_array : []) :
+    binding => {
+      topic   = element(split(" ", binding), 0)
+      role    = element(split(" ", binding), 1)
+      members = compact(split(" ", element(split("=", binding), 1)))
+    }
+  }
 
-  topic   = element(split(" ", local.bindings_array[count.index]), 0)
   project = local.resources_project
-  role    = element(split(" ", local.bindings_array[count.index]), 1)
-
-  members = compact(
-    split(
-      " ",
-      element(split("=", local.bindings_array[count.index]), 1),
-    ),
-  )
+  topic   = each.value.topic
+  role    = each.value.role
+  members = each.value.members
 }
 
 /******************************************
   Pubsub topic IAM binding additive
  *****************************************/
 resource "google_pubsub_topic_iam_member" "pubsub_topic_iam_additive" {
-  count = local.pubsub_topics_additive_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.pubsub_topics_additive_iam ? local.bindings_array : []) :
+    binding => {
+      topic  = element(split(" ", binding), 0)
+      member = element(split(" ", binding), 1)
+      role   = element(split(" ", binding), 2)
+    }
+  }
 
-  topic   = element(split(" ", local.bindings_array[count.index]), 0)
   project = local.resources_project
-  member  = element(split(" ", local.bindings_array[count.index]), 1)
-  role    = element(split(" ", local.bindings_array[count.index]), 2)
+  topic   = each.value.topic
+  member  = each.value.member
+  role    = each.value.role
 }
-

--- a/service_accounts_iam.tf
+++ b/service_accounts_iam.tf
@@ -18,27 +18,34 @@
   Service Account IAM binding authoritative
  *****************************************/
 resource "google_service_account_iam_binding" "service_account_iam_authoritative" {
-  count = local.service_accounts_authoritative_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.service_accounts_authoritative_iam ? local.bindings_array : []) :
+    binding => {
+      service_account_id = element(split(" ", binding), 0)
+      role               = element(split(" ", binding), 1)
+      members            = compact(split(" ", element(split("=", binding), 1)))
+    }
+  }
 
-  service_account_id = element(split(" ", local.bindings_array[count.index]), 0)
-  role               = element(split(" ", local.bindings_array[count.index]), 1)
-
-  members = compact(
-    split(
-      " ",
-      element(split("=", local.bindings_array[count.index]), 1),
-    ),
-  )
+  service_account_id = each.value.service_account_id
+  role               = each.value.role
+  members            = each.value.members
 }
 
 /******************************************
   Service Account IAM binding additive
  *****************************************/
 resource "google_service_account_iam_member" "service_account_iam_additive" {
-  count = local.service_accounts_additive_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.service_accounts_additive_iam ? local.bindings_array : []) :
+    binding => {
+      service_account_id = element(split(" ", binding), 0)
+      member             = element(split(" ", binding), 1)
+      role               = element(split(" ", binding), 2)
+    }
+  }
 
-  service_account_id = element(split(" ", local.bindings_array[count.index]), 0)
-  member             = element(split(" ", local.bindings_array[count.index]), 1)
-  role               = element(split(" ", local.bindings_array[count.index]), 2)
+  service_account_id = each.value.service_account_id
+  member             = each.value.member
+  role               = each.value.role
 }
-

--- a/storage_buckets_iam.tf
+++ b/storage_buckets_iam.tf
@@ -18,27 +18,34 @@
   Storage bucket IAM binding authoritative
  *****************************************/
 resource "google_storage_bucket_iam_binding" "storage_bucket_iam_authoritative" {
-  count = local.storage_buckets_authoritative_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.storage_buckets_authoritative_iam ? local.bindings_array : []) :
+    binding => {
+      bucket  = element(split(" ", binding), 0)
+      role    = element(split(" ", binding), 1)
+      members = compact(split(" ", element(split("=", binding), 1)))
+    }
+  }
 
-  bucket = element(split(" ", local.bindings_array[count.index]), 0)
-  role   = element(split(" ", local.bindings_array[count.index]), 1)
-
-  members = compact(
-    split(
-      " ",
-      element(split("=", local.bindings_array[count.index]), 1),
-    ),
-  )
+  bucket  = each.value.bucket
+  role    = each.value.role
+  members = each.value.members
 }
 
 /******************************************
   Storage bucket IAM binding additive
  *****************************************/
 resource "google_storage_bucket_iam_member" "storage_bucket_iam_additive" {
-  count = local.storage_buckets_additive_iam ? length(local.bindings_array) : 0
+  for_each = {
+    for binding in(local.storage_buckets_additive_iam ? local.bindings_array : []) :
+    binding => {
+      bucket = element(split(" ", binding), 0)
+      member = element(split(" ", binding), 1)
+      role   = element(split(" ", binding), 2)
+    }
+  }
 
-  bucket = element(split(" ", local.bindings_array[count.index]), 0)
-  member = element(split(" ", local.bindings_array[count.index]), 1)
-  role   = element(split(" ", local.bindings_array[count.index]), 2)
+  bucket = each.value.bucket
+  member = each.value.member
+  role   = each.value.role
 }
-

--- a/subnets_iam.tf
+++ b/subnets_iam.tf
@@ -19,37 +19,23 @@
  *****************************************/
 resource "google_compute_subnetwork_iam_binding" "subnet_iam_authoritative" {
   provider = google-beta
-  count    = local.subnets_authoritative_iam ? length(local.bindings_array) : 0
 
-  subnetwork = element(
-    split(
-      "/",
-      element(split(" ", local.bindings_array[count.index]), 0),
-    ),
-    5,
-  )
-  region = element(
-    split(
-      "/",
-      element(split(" ", local.bindings_array[count.index]), 0),
-    ),
-    3,
-  )
-  project = element(
-    split(
-      "/",
-      element(split(" ", local.bindings_array[count.index]), 0),
-    ),
-    1,
-  )
-  role = element(split(" ", local.bindings_array[count.index]), 1)
+  for_each = {
+    for binding in(local.subnets_authoritative_iam ? local.bindings_array : []) :
+    binding => {
+      subnetwork = element(split("/", element(split(" ", binding), 0)), 5)
+      region     = element(split("/", element(split(" ", binding), 0)), 3)
+      project    = element(split("/", element(split(" ", binding), 0)), 1)
+      role       = element(split(" ", binding), 1)
+      members    = compact(split(" ", element(split("=", binding), 1)))
+    }
+  }
 
-  members = compact(
-    split(
-      " ",
-      element(split("=", local.bindings_array[count.index]), 1),
-    ),
-  )
+  subnetwork = each.value.subnetwork
+  region     = each.value.region
+  project    = each.value.project
+  role       = each.value.role
+  members    = each.value.members
 }
 
 /******************************************
@@ -57,30 +43,21 @@ resource "google_compute_subnetwork_iam_binding" "subnet_iam_authoritative" {
  *****************************************/
 resource "google_compute_subnetwork_iam_member" "subnet_iam_additive" {
   provider = google-beta
-  count    = local.subnets_additive_iam ? length(local.bindings_array) : 0
 
-  subnetwork = element(
-    split(
-      "/",
-      element(split(" ", local.bindings_array[count.index]), 0),
-    ),
-    5,
-  )
-  region = element(
-    split(
-      "/",
-      element(split(" ", local.bindings_array[count.index]), 0),
-    ),
-    3,
-  )
-  project = element(
-    split(
-      "/",
-      element(split(" ", local.bindings_array[count.index]), 0),
-    ),
-    1,
-  )
-  member = element(split(" ", local.bindings_array[count.index]), 1)
-  role   = element(split(" ", local.bindings_array[count.index]), 2)
+  for_each = {
+    for binding in(local.subnets_additive_iam ? local.bindings_array : []) :
+    binding => {
+      subnetwork = element(split("/", element(split(" ", binding), 0)), 5)
+      region     = element(split("/", element(split(" ", binding), 0)), 3)
+      project    = element(split("/", element(split(" ", binding), 0)), 1)
+      member     = element(split(" ", binding), 1)
+      role       = element(split(" ", binding), 2)
+    }
+  }
+
+  subnetwork = each.value.subnetwork
+  region     = each.value.region
+  project    = each.value.project
+  member     = each.value.member
+  role       = each.value.role
 }
-

--- a/test/fixtures/full/base/versions.tf
+++ b/test/fixtures/full/base/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.6"
 }

--- a/test/fixtures/full/versions.tf
+++ b/test/fixtures/full/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.6"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.6"
 }


### PR DESCRIPTION
This is a pretty large change which uses Terraform 0.12.6's new resource-level `for_each` keyword instead of `count` to create >1 instances of the same resource. See https://github.com/hashicorp/terraform/pull/21922 for implementation details.

It solves the general Terraform problem that, when `count` is used to create multiple resources, each resource is an element in a list, meaning if one is deleted/moved from the middle of the list (thus changing its numeric index), the entire list is reshuffled and a bunch of resources are destroyed/(re)created as a result. See https://github.com/hashicorp/terraform/issues/14275 for the main bug report.

Fixes https://github.com/terraform-google-modules/terraform-google-iam/issues/38
