### PR TITLE
Add bucket tests

### DIFF
--- a/test/fixtures/full/base/main.tf
+++ b/test/fixtures/full/base/main.tf
@@ -27,11 +27,7 @@ resource "google_folder" "test" {
   count = local.n
 
   display_name = "${local.prefix}-folder-${count.index}-${random_id.test[count.index].hex}"
-  # Parent folder must be specified in the format of "folders/<parent_id>"
-  # https://cloud.google.com/resource-manager/reference/rest/v2/folders/create
-  # Also make sure that your service account has the "resourcemanager.folders.create" (Folder Creator)
-  # role for the parent_id folder.
-  parent       = "folders/${var.base_parent_id}"
+  parent       = var.base_parent_id
 }
 
 # Projects

--- a/test/fixtures/full/base/main.tf
+++ b/test/fixtures/full/base/main.tf
@@ -27,7 +27,11 @@ resource "google_folder" "test" {
   count = local.n
 
   display_name = "${local.prefix}-folder-${count.index}-${random_id.test[count.index].hex}"
-  parent       = var.base_parent_id
+  # Parent folder must be specified in the format of "folders/<parent_id>"
+  # https://cloud.google.com/resource-manager/reference/rest/v2/folders/create
+  # Also make sure that your service account has the "resourcemanager.folders.create" (Folder Creator)
+  # role for the parent_id folder.
+  parent       = "folders/${var.base_parent_id}"
 }
 
 # Projects
@@ -114,4 +118,3 @@ resource "google_compute_subnetwork" "test" {
   ip_cidr_range = local.subnet_cdir[count.index]
   network       = "default"
 }
-

--- a/test/fixtures/full/outputs.tf
+++ b/test/fixtures/full/outputs.tf
@@ -114,3 +114,8 @@ output "project_id" {
   value       = var.project_id
   description = "Project ID of the test fixture project. Used to avoid timing issues with recently created projects."
 }
+
+output "mode" {
+  value       = var.mode
+  description = "Mode of IAM management ('authoritative' OR 'additive')."
+}

--- a/test/fixtures/full/variables.tf
+++ b/test/fixtures/full/variables.tf
@@ -50,3 +50,8 @@ variable "member2" {
   type        = string
   description = "Member created for binding with roles."
 }
+
+variable "org_id" {
+  type        = string
+  description = "Organization ID"
+}

--- a/test/integration/full/controls/gcloud.rb
+++ b/test/integration/full/controls/gcloud.rb
@@ -92,6 +92,38 @@ assert_bindings(
   member_groups[1],
 )
 
+# Buckets
+
+def assert_bucket_bindings(name, project, bucket, expected_role, expected_members)
+  assert_bindings(
+    name,
+    # TODO: Remove explicit `--format='json(bindings)'` since it doesn't seem to be needed in gsutil,
+    #       and I haven't even found any support for it at all.
+    #       Gsutil already returns JSON for iam bindings by default.
+    #       We might leave it for the case of future gsutil api changes which might bring in the gcloud apis.
+    "gsutil iam get gs://#{bucket} --project='#{project}' --format='json(bindings)'",
+    expected_role,
+    maybe_add_default_members_for_role(expected_role, expected_members, project)
+  )
+end
+
+# Patch expected list of members of the bucket with the default users.
+# Example:
+#   role 'roles/storage.legacyBucketReader' is granted to all project viewers by default on bucket creation.
+def maybe_add_default_members_for_role(role, members, project)
+  case role
+  when 'roles/storage.legacyBucketReader'
+    return ["projectViewer:#{project}"] + members # Order matters
+  else
+    return members
+  end
+end
+
+assert_bucket_bindings('bucket-0-role-0', projects[0], buckets[0], bucket_roles[0], member_groups[0])
+assert_bucket_bindings('bucket-0-role-1', projects[0], buckets[0], bucket_roles[1], member_groups[1])
+assert_bucket_bindings('bucket-1-role-0', projects[0], buckets[1], bucket_roles[0], member_groups[0])
+assert_bucket_bindings('bucket-1-role-1', projects[0], buckets[1], bucket_roles[1], member_groups[1])
+
 # Projects
 
 assert_bindings(

--- a/test/integration/full/inspec.yml
+++ b/test/integration/full/inspec.yml
@@ -68,3 +68,6 @@ attributes:
   - name: folder_roles
     required: true
     type: array
+  - name: mode
+    required: true
+    type: string


### PR DESCRIPTION
- Add bucket tests with the support for both modes
- Fix test infrastructure provisioning during `kitchen converge`: add missing variables, fix folders creation.

Testing particular roles in the bucket turned out to be a bit tricky, since some of the roles are assigned by default to project viewers, etc.

Abstracted away the hardcoding of the default list of roles patching into a separate `maybe_add_default_members_for_role` function.

Logs of the tests passing:
https://gist.github.com/cray0000/b4e7d8c38dc9c2ca39bc2a2109ba6b6d
IMPORTANT: That suite doesn't not have the folders tests. I had to comment it out because the provisioning of folders in the fixtures project didn't work because of some kind of a `invalid arguments 400 error` which I'm yet to debug.

Also fix the tests configuration in the current master. Some of the variables were missing from the variable definitions and from the variables boilerplate.