### PR TITLE
add readme headers

### DIFF
--- a/examples/billing_account/README.md
+++ b/examples/billing_account/README.md
@@ -1,3 +1,7 @@
+# Billing Account Example
+
+This example illustrates how to use the `billing_accounts_iam` submodule
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 

--- a/examples/folder/README.md
+++ b/examples/folder/README.md
@@ -1,3 +1,7 @@
+# Folder Example
+
+This example illustrates how to use the `folders_iam` submodule
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 

--- a/examples/kms_crypto_key/README.md
+++ b/examples/kms_crypto_key/README.md
@@ -1,3 +1,7 @@
+# KMS Crypto Key Example
+
+This example illustrates how to use the `kms_crypto_keys_iam` submodule
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 

--- a/examples/kms_key_ring/README.md
+++ b/examples/kms_key_ring/README.md
@@ -1,3 +1,7 @@
+# KMS Key Ring Example
+
+This example illustrates how to use the `kms_key_rings_iam` submodule
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 

--- a/examples/organization/README.md
+++ b/examples/organization/README.md
@@ -1,3 +1,7 @@
+# Organization Example
+
+This example illustrates how to use the `organizations_iam` submodule
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 

--- a/examples/project/README.md
+++ b/examples/project/README.md
@@ -1,3 +1,7 @@
+# Project Example
+
+This example illustrates how to use the `projects_iam` submodule
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 

--- a/examples/pubsub_subscription/README.md
+++ b/examples/pubsub_subscription/README.md
@@ -1,3 +1,7 @@
+# PubSub Subscription Example
+
+This example illustrates how to use the `pubsub_subscriptions_iam` submodule
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 

--- a/examples/pubsub_topic/README.md
+++ b/examples/pubsub_topic/README.md
@@ -1,3 +1,7 @@
+# PubSub Topic Example
+
+This example illustrates how to use the `pubsub_topics_iam` submodule
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 

--- a/examples/service_account/README.md
+++ b/examples/service_account/README.md
@@ -1,3 +1,7 @@
+# Service Account Example
+
+This example illustrates how to use the `service_accounts_iam` submodule
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 

--- a/examples/storage_bucket/README.md
+++ b/examples/storage_bucket/README.md
@@ -1,3 +1,7 @@
+# Storage Bucket Example
+
+This example illustrates how to use the `storage_buckets_iam` submodule
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 

--- a/examples/subnet/README.md
+++ b/examples/subnet/README.md
@@ -1,3 +1,7 @@
+# Subnet Example
+
+This example illustrates how to use the `subnets_iam` submodule
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 


### PR DESCRIPTION
Fixes #79 

Simple headers at the top of example READMEs. 

Corresponding submodule's READMEs have good usage examples already