### PR TITLE
Remove deprecated syntax

### DIFF
--- a/modules/custom_role_iam/main.tf
+++ b/modules/custom_role_iam/main.tf
@@ -17,7 +17,7 @@
 locals {
   excluded_permissions = concat(data.google_iam_testable_permissions.unsupported_permissions.permissions[*].name, var.excluded_permissions)
   included_permissions = concat(flatten(values(data.google_iam_role.role_permissions)[*].included_permissions), var.permissions)
-  permissions          = [for permission in local.included_permissions : permission if ! contains(local.excluded_permissions, permission)]
+  permissions          = [for permission in local.included_permissions : permission if !contains(local.excluded_permissions, permission)]
   custom-role-output   = (var.target_level == "project") ? google_project_iam_custom_role.project-custom-role[0].role_id : google_organization_iam_custom_role.org-custom-role[0].role_id
 }
 
@@ -26,7 +26,7 @@ locals {
  *****************************************/
 data "google_iam_role" "role_permissions" {
   for_each = toset(var.base_roles)
-  name     = "${each.value}"
+  name     = each.value
 }
 
 /******************************************

--- a/modules/custom_role_iam/main.tf
+++ b/modules/custom_role_iam/main.tf
@@ -17,7 +17,7 @@
 locals {
   excluded_permissions = concat(data.google_iam_testable_permissions.unsupported_permissions.permissions[*].name, var.excluded_permissions)
   included_permissions = concat(flatten(values(data.google_iam_role.role_permissions)[*].included_permissions), var.permissions)
-  permissions          = [for permission in local.included_permissions : permission if !contains(local.excluded_permissions, permission)]
+  permissions          = [for permission in local.included_permissions : permission if ! contains(local.excluded_permissions, permission)]
   custom-role-output   = (var.target_level == "project") ? google_project_iam_custom_role.project-custom-role[0].role_id : google_organization_iam_custom_role.org-custom-role[0].role_id
 }
 

--- a/modules/pubsub_topics_iam/README.md
+++ b/modules/pubsub_topics_iam/README.md
@@ -30,7 +30,7 @@ module "pubsub_topic-iam-bindings" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| bindings | Map of role (key) and list of members (value) to add the IAM policies/bindings | map | n/a | yes |
+| bindings | Map of role (key) and list of members (value) to add the IAM policies/bindings | map(any) | n/a | yes |
 | mode | Mode for adding the IAM policies/bindings, additive and authoritative | string | `"additive"` | no |
 | project | Project to add the IAM policies/bindings | string | `""` | no |
 | pubsub\_topics | PubSub Topics list to add the IAM policies/bindings | list(string) | `<list>` | no |

--- a/modules/pubsub_topics_iam/variables.tf
+++ b/modules/pubsub_topics_iam/variables.tf
@@ -33,5 +33,5 @@ variable "mode" {
 
 variable "bindings" {
   description = "Map of role (key) and list of members (value) to add the IAM policies/bindings"
-  type        = map
+  type        = map(any)
 }


### PR DESCRIPTION
I noticed deprecated syntax in custom_role_iam (interpolation-only expression). This PR solves the problem and also improve format in two places. All changes are done by `terraform fmt`.