### PR TITLE
feat: Add tasks_queue_iam submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This is a collection of submodules that make it easier to non-destructively mana
 * [Storage Buckets IAM](modules/storage_buckets_iam)
 * [Subnets IAM](modules/subnets_iam)
 * [Secret Manager IAM](modules/secret_manager_iam)
+* [Tasks Queue IAM](modules/tasks_queue_iam)
 
 ## Compatibility
 This module is meant for use with Terraform 0.13+ and tested using Terraform 1.0+. If you find incompatibilities using Terraform >=0.13, please open an issue.

--- a/examples/tasks_queue/README.md
+++ b/examples/tasks_queue/README.md
@@ -1,0 +1,22 @@
+# Tasks Queue Example
+
+This example illustrates how to use the `tasks_queue_iam` submodule
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| group\_email | Email for group to receive roles (ex. group@example.com) | `string` | n/a | yes |
+| sa\_email | Email for Service Account to receive roles (Ex. default-sa@example-project-id.iam.gserviceaccount.com) | `string` | n/a | yes |
+| tasks\_queue\_location | Region of the Tasks Queue | `string` | n/a | yes |
+| tasks\_queue\_one | First Tasks Queue to add the IAM policies/bindings | `string` | n/a | yes |
+| tasks\_queue\_project | Project id of the Tasks Queue | `string` | n/a | yes |
+| tasks\_queue\_two | Second Tasks Queue to add the IAM policies/bindings | `string` | n/a | yes |
+| user\_email | Email for group to receive roles (Ex. user@example.com) | `string` | n/a | yes |
+
+## Outputs
+
+No output.
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/tasks_queue/main.tf
+++ b/examples/tasks_queue/main.tf
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# /******************************************
+#   Module tasks_queue_iam_member calling
+#  *****************************************/
+module "tasks_queue_iam_member" {
+  source       = "../../modules/tasks_queue_iam"
+  project      = var.tasks_queue_project
+  tasks_queues = [var.tasks_queue_one, var.tasks_queue_two]
+  location     = var.tasks_queue_location
+  mode         = "additive"
+
+  bindings = {
+    "roles/cloudtasks.enqueuer" = [
+      "serviceAccount:${var.sa_email}",
+      "group:${var.group_email}",
+      "user:${var.user_email}",
+    ]
+  }
+}

--- a/examples/tasks_queue/variables.tf
+++ b/examples/tasks_queue/variables.tf
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "group_email" {
+  type        = string
+  description = "Email for group to receive roles (ex. group@example.com)"
+}
+
+variable "sa_email" {
+  type        = string
+  description = "Email for Service Account to receive roles (Ex. default-sa@example-project-id.iam.gserviceaccount.com)"
+}
+
+variable "user_email" {
+  type        = string
+  description = "Email for group to receive roles (Ex. user@example.com)"
+}
+
+/******************************************
+  pubsub_topic_iam_binding variables
+ *****************************************/
+variable "tasks_queue_project" {
+  type        = string
+  description = "Project id of the Tasks Queue"
+}
+
+variable "tasks_queue_location" {
+  type        = string
+  description = "Region of the Tasks Queue"
+}
+
+variable "tasks_queue_one" {
+  type        = string
+  description = "First Tasks Queue to add the IAM policies/bindings"
+}
+
+variable "tasks_queue_two" {
+  type        = string
+  description = "Second Tasks Queue to add the IAM policies/bindings"
+}
+

--- a/examples/tasks_queue/versions.tf
+++ b/examples/tasks_queue/versions.tf
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.28, < 5.0"
+    }
+  }
+}

--- a/modules/tasks_queue_iam/README.md
+++ b/modules/tasks_queue_iam/README.md
@@ -1,0 +1,44 @@
+# Module Tasks Queue IAM
+
+This optional module is used to assign secrets roles
+
+## Usage
+
+```hcl
+module "secret_manager_iam" {
+  source       = "terraform-google-modules/iam/google//modules/tasks_queue_iam"
+  project      = "gcp-project-id"
+  tasks_queues = ["tasks-queue-one", "tasks-queue-two"]
+  location     = "us-central1"
+  mode         = "additive"
+
+  bindings = {
+    "roles/cloudtasks.enqueuer" = [
+      "serviceAccount:my-sa@my-project.iam.gserviceaccount.com",
+      "group:my-group@my-org.com",
+      "user:my-user@my-org.com",
+    ]
+  }
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| bindings | Map of role (key) and list of members (value) to add the IAM policies/bindings | `map(list(string))` | `{}` | no |
+| location | Location of the provided tasks queues | `string` | n/a | yes |
+| mode | Mode for adding the IAM policies/bindings, additive and authoritative | `string` | `"additive"` | no |
+| project | Project to add the IAM policies/bindings | `string` | `""` | no |
+| tasks\_queues | Tasks Queues list to add the IAM policies/bindings | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| members | Members which were bound to the Tasks Queues. |
+| roles | Roles which were assigned to members. |
+| tasks\_queues | Tasks Queues which received bindings. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/tasks_queue_iam/README.md
+++ b/modules/tasks_queue_iam/README.md
@@ -1,11 +1,11 @@
 # Module Tasks Queue IAM
 
-This optional module is used to assign secrets roles
+This optional module is used to assign Tasks queue roles
 
 ## Usage
 
 ```hcl
-module "secret_manager_iam" {
+module "tasks_queue_iam" {
   source       = "terraform-google-modules/iam/google//modules/tasks_queue_iam"
   project      = "gcp-project-id"
   tasks_queues = ["tasks-queue-one", "tasks-queue-two"]

--- a/modules/tasks_queue_iam/main.tf
+++ b/modules/tasks_queue_iam/main.tf
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/******************************************
+  Run helper module to get generic calculated data
+ *****************************************/
+module "helper" {
+  source   = "../helper"
+  bindings = var.bindings
+  mode     = var.mode
+  entities = var.tasks_queues
+}
+
+/******************************************
+  Tasks Queue IAM binding authoritative
+ *****************************************/
+resource "google_cloud_tasks_queue_iam_binding" "tasks_queue_iam_authoritative" {
+  for_each = module.helper.set_authoritative
+  project  = var.project
+  name     = module.helper.bindings_authoritative[each.key].name
+  role     = module.helper.bindings_authoritative[each.key].role
+  members  = module.helper.bindings_authoritative[each.key].members
+  location = var.location
+}
+
+/******************************************
+  Tasks Queue IAM binding additive
+ *****************************************/
+resource "google_cloud_tasks_queue_iam_member" "tasks_queue_iam_additive" {
+  for_each = module.helper.set_additive
+  project  = var.project
+  name     = module.helper.bindings_additive[each.key].name
+  role     = module.helper.bindings_additive[each.key].role
+  member   = module.helper.bindings_additive[each.key].member
+  location = var.location
+}

--- a/modules/tasks_queue_iam/outputs.tf
+++ b/modules/tasks_queue_iam/outputs.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "tasks_queues" {
+  value       = distinct(module.helper.bindings_by_member[*].name)
+  description = "Tasks Queues which received bindings."
+  depends_on  = [google_cloud_tasks_queue_iam_binding.tasks_queue_iam_authoritative, google_cloud_tasks_queue_iam_member.tasks_queue_iam_additive]
+}
+
+output "roles" {
+  value       = distinct(module.helper.bindings_by_member[*].role)
+  description = "Roles which were assigned to members."
+}
+
+output "members" {
+  value       = distinct(module.helper.bindings_by_member[*].member)
+  description = "Members which were bound to the Tasks Queues."
+}

--- a/modules/tasks_queue_iam/variables.tf
+++ b/modules/tasks_queue_iam/variables.tf
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project" {
+  description = "Project to add the IAM policies/bindings"
+  default     = ""
+  type        = string
+}
+
+variable "tasks_queues" {
+  description = "Tasks Queues list to add the IAM policies/bindings"
+  default     = []
+  type        = list(string)
+}
+
+variable "location" {
+  description = "Location of the provided tasks queues"
+  type        = string
+}
+
+variable "mode" {
+  description = "Mode for adding the IAM policies/bindings, additive and authoritative"
+  default     = "additive"
+}
+
+variable "bindings" {
+  description = "Map of role (key) and list of members (value) to add the IAM policies/bindings"
+  type        = map(list(string))
+  default     = {}
+}

--- a/modules/tasks_queue_iam/versions.tf
+++ b/modules/tasks_queue_iam/versions.tf
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.28, < 5.0"
+    }
+  }
+}


### PR DESCRIPTION
Adding a `tasks_queue_iam` submodule to manage roles on Cloud Tasks queues.