### PR TITLE
chore: Make artifact registry example usable

### DIFF
--- a/modules/artifact_registry_iam/README.md
+++ b/modules/artifact_registry_iam/README.md
@@ -8,11 +8,11 @@ module "artifact-registry-repository-iam-bindings" {
   source   = "terraform-google-modules/iam/google//modules/artifact_registry_iam"
   project      = "my-project"
   repositories = ["my-project_one", "my-project_two"]
-  location     = "us-central-1"
+  location     = "us-central1"
   mode         = "additive"
 
   bindings = {
-    "roles/compute.networkAdmin" = [
+    "roles/artifactregistry.writer" = [
       "serviceAccount:my-sa@my-project.iam.gserviceaccount.com",
       "group:my-group@my-org.com",
       "user:my-user@my-org.com",


### PR DESCRIPTION
This change adds an applicable role and sets the environment to an actual instance of a real location in the ReadME.