### PR TITLE
feat: Add IAP Web Backend Services IAM module and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a collection of submodules that make it easier to non-destructively mana
 * [Custom Role IAM](modules/custom_role_iam)
 * [DNS Zone IAM](modules/dns_zones_iam)
 * [Folders IAM](modules/folders_iam)
+* [IAP Web Backend Services IAM](modules/iap_web_backend_services_iam)
 * [KMS Crypto Keys IAM](modules/kms_crypto_keys_iam)
 * [KMS_Key Rings IAM](modules/kms_key_rings_iam)
 * [Organizations IAM](modules/organizations_iam)
@@ -126,6 +127,7 @@ You can choose the following resource types to apply the IAM bindings:
 - Kms Crypto Keys (`kms_crypto_keys` variable)
 - Secret Manager Secrets (`secrets` variable)
 - DNS Zones (`managed_zones` variable)
+- IAP Web Backend Services (`web_backend_services` and `project` variables)
 - Secure Source Manager (`entity_ids` and `location` variable)
 
 Set the specified variable on the module call to choose the resources to affect. Remember to set the `mode` [variable](#additive-and-authoritative-modes) and give enough [permissions](#permissions) to manage the selected resource as well. Note that the `bindings` variable accepts an empty map `{}` passed in as an argument in the case that resources don't have IAM bindings to apply.
@@ -143,55 +145,50 @@ Set the specified variable on the module call to choose the resources to affect.
 In order to execute a submodule you must have a Service Account with an appropriate role to manage IAM for the applicable resource. The appropriate role differs depending on which resource you are targeting, as follows:
 
 - Organization:
-  - Organization Administrator: Access to administer all resources belonging to the organization
-    and does not include privileges for billing or organization role administration.
-  - Custom: Add resourcemanager.organizations.getIamPolicy and
-    resourcemanager.organizations.setIamPolicy permissions.
+  - Organization Administrator: Access to administer all resources belonging to the organization and does not include privileges for billing or organization role administration.
+  - Custom: Add `resourcemanager.organizations.getIamPolicy` and `resourcemanager.organizations.setIamPolicy` permissions.
 - Project:
   - Owner: Full access and all permissions for all resources of the project.
   - Projects IAM Admin: allows users to administer IAM policies on projects.
-  - Custom: Add resourcemanager.projects.getIamPolicy and resourcemanager.projects.setIamPolicy permissions.
+  - Custom: Add `resourcemanager.projects.getIamPolicy` and `resourcemanager.projects.setIamPolicy` permissions.
 - Folder:
   - The Folder Admin: All available folder permissions.
   - Folder IAM Admin: Allows users to administer IAM policies on folders.
-  - Custom: Add resourcemanager.folders.getIamPolicy and
-    resourcemanager.folders.setIamPolicy permissions (must be added in the organization).
+  - Custom: Add `resourcemanager.folders.getIamPolicy` and `resourcemanager.folders.setIamPolicy` permissions (must be added in the organization).
 - Service Account:
   - Service Account Admin: Create and manage service accounts.
-  - Custom: Add resourcemanager.organizations.getIamPolicy and
-    resourcemanager.organizations.setIamPolicy permissions.
+  - Custom: Add `iam.serviceAccounts.getIamPolicy` and `iam.serviceAccounts.setIamPolicy` permissions.
 - Subnetwork:
   - Project compute admin: Full control of Compute Engine resources.
   - Project compute network admin: Full control of Compute Engine networking resources.
-  - Project custom: Add compute.subnetworks.getIamPolicy	and
-    compute.subnetworks.setIamPolicy permissions.
+  - Project custom: Add `compute.subnetworks.getIamPolicy` and `compute.subnetworks.setIamPolicy` permissions.
 - Storage bucket:
   - Storage Admin: Full control of GCS resources.
-  - Storage Legacy Bucket Owner: Read and write access to existing
-    buckets with object listing/creation/deletion.
-  - Custom: Add storage.buckets.getIamPolicy	and
-  storage.buckets.setIamPolicy permissions.
+  - Storage Legacy Bucket Owner: Read and write access to existing buckets with object listing/creation/deletion.
+  - Custom: Add `storage.buckets.getIamPolicy` and `storage.buckets.setIamPolicy` permissions.
 - Pubsub topic:
   - Pub/Sub Admin: Create and manage service accounts.
-  - Custom: Add pubsub.topics.getIamPolicy and pubsub.topics.setIamPolicy permissions.
+  - Custom: Add `pubsub.topics.getIamPolicy` and `pubsub.topics.setIamPolicy` permissions.
 - Pubsub subscription:
   - Pub/Sub Admin role: Create and manage service accounts.
-  - Custom role: Add pubsub.subscriptions.getIamPolicy and
-    pubsub.subscriptions.setIamPolicy permissions.
+  - Custom role: Add `pubsub.subscriptions.getIamPolicy` and `pubsub.subscriptions.setIamPolicy` permissions.
 - Kms Key Ring:
   - Owner: Full access to all resources.
   - Cloud KMS Admin: Enables management of crypto resources.
-  - Custom: Add cloudkms.keyRings.getIamPolicy and cloudkms.keyRings.getIamPolicy permissions.
+  - Custom: Add `cloudkms.keyRings.getIamPolicy` and `cloudkms.keyRings.setIamPolicy` permissions.
 - Kms Crypto Key:
   - Owner: Full access to all resources.
   - Cloud KMS Admin: Enables management of cryptoresources.
-  - Custom: Add cloudkms.cryptoKeys.getIamPolicy	and cloudkms.cryptoKeys.setIamPolicy permissions.
+  - Custom: Add `cloudkms.cryptoKeys.getIamPolicy`	and `cloudkms.cryptoKeys.setIamPolicy` permissions.
 - Secret Manager:
-    - Secret Manager Admin: Full access to administer Secret Manager.
-    - Custom: Add secretmanager.secrets.getIamPolicy and secretmanager.secrets.setIamPolicy permissions.
+  - Secret Manager Admin: Full access to administer Secret Manager.
+  - Custom: Add `secretmanager.secrets.getIamPolicy` and `secretmanager.secrets.setIamPolicy` permissions.
 - DNS Zone:
-    - DNS Administrator : Full access to administer DNS Zone.
-    - Custom: Add dns.managedZones.setIamPolicy, dns.managedZones.list and dns.managedZones.getIamPolicy permissions.
+  - DNS Administrator : Full access to administer DNS Zone.
+  - Custom: Add `dns.managedZones.setIamPolicy`, `dns.managedZones.list` and `dns.managedZones.getIamPolicy` permissions.
+- IAP Web Backend Service:
+  - IAP Policy Admin: Grants permissions to manage access policies for IAP resources.
+  - Custom: Add `iap.webServices.getIamPolicy` and `iap.webServices.setIamPolicy` permissions.
 
 ## Install
 

--- a/examples/iap_web_backend_service/README.md
+++ b/examples/iap_web_backend_service/README.md
@@ -1,0 +1,19 @@
+# IAP Web Backend Example
+
+This example illustrates how to use the `iap_web_backend_services_iam` submodule 
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| group\_email | Email for group to receive IAP roles (e.g., group@example.com) | `string` | `"iap_viewers_group@example.com"` | no |
+| project\_id | The project ID to host the backend service and apply IAM policies | `string` | n/a | yes |
+| user\_email | Email for user to receive IAP roles (e.g., user@example.com) | `string` | `"iap_user@example.com"` | no |
+| web\_backend\_service\_additive\_names | A list of existing web backend service names to apply additive IAM policies to. | `list(string)` | <pre>[<br>  "iap-example-service"<br>]</pre> | no |
+| web\_backend\_service\_authoritative\_names | A list of existing web backend service names to apply authoritative IAM policies to. | `list(string)` | <pre>[<br>  "iap-example-service"<br>]</pre> | no |
+
+## Outputs
+
+No outputs.
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iap_web_backend_service/main.tf
+++ b/examples/iap_web_backend_service/main.tf
@@ -1,0 +1,51 @@
+module "iap_web_backend_service_iam_bindings" {
+  source  = "terraform-google-modules/iam/google//modules/iap_web_backend_services_iam"
+  version = "~> 8.0"
+
+  project              = var.project_id
+  web_backend_services = var.web_backend_service_additive_names
+  mode                 = "additive"
+
+  bindings = {
+    "roles/iap.httpsResourceAccessor" = [
+      "group:${var.group_email}",
+      "user:${var.user_email}",
+    ]
+  }
+
+  conditional_bindings = [
+    {
+      role        = "roles/iap.httpsResourceAccessor"
+      title       = "expires_after_2025_12_31"
+      description = "Expiring at midnight of 2025-12-31"
+      expression  = "request.time < timestamp(\"2026-01-01T00:00:00Z\")"
+      members     = ["group:${var.group_email}"]
+    }
+  ]
+}
+
+module "iap_web_backend_service_iam_bindings_authoritative" {
+  source  = "terraform-google-modules/iam/google//modules/iap_web_backend_services_iam"
+  version = "~> 8.0"
+
+  project              = var.project_id
+  web_backend_services = var.web_backend_service_authoritative_names
+  mode                 = "authoritative"
+
+  bindings = {
+    "roles/iap.httpsResourceAccessor" = [
+      "group:${var.group_email}",
+      "user:${var.user_email}",
+    ]
+  }
+
+  conditional_bindings = [
+    {
+      role        = "roles/iap.httpsResourceAccessor"
+      title       = "expires_after_2025_12_31"
+      description = "Expiring at midnight of 2025-12-31"
+      expression  = "request.time < timestamp(\"2026-01-01T00:00:00Z\")"
+      members     = ["group:${var.group_email}"]
+    }
+  ]
+}

--- a/examples/iap_web_backend_service/variables.tf
+++ b/examples/iap_web_backend_service/variables.tf
@@ -1,0 +1,28 @@
+variable "project_id" {
+  type        = string
+  description = "The project ID to host the backend service and apply IAM policies"
+}
+
+variable "group_email" {
+  type        = string
+  description = "Email for group to receive IAP roles (e.g., group@example.com)"
+  default     = "iap_viewers_group@example.com"
+}
+
+variable "user_email" {
+  type        = string
+  description = "Email for user to receive IAP roles (e.g., user@example.com)"
+  default     = "iap_user@example.com"
+}
+
+variable "web_backend_service_authoritative_names" {
+  type        = list(string)
+  description = "A list of existing web backend service names to apply authoritative IAM policies to."
+  default     = ["iap-example-service"]
+}
+
+variable "web_backend_service_additive_names" {
+  type        = list(string)
+  description = "A list of existing web backend service names to apply additive IAM policies to."
+  default     = ["iap-example-service"]
+}

--- a/modules/iap_web_backend_services_iam/README.md
+++ b/modules/iap_web_backend_services_iam/README.md
@@ -1,0 +1,55 @@
+# Module iap_web_backend_services_iam
+
+This module is used to manage IAM policies for IAP (Identity-Aware Proxy) Web Backend Services.
+
+## Example Usage
+
+```hcl
+module "iap_web_backend_services_iam_bindings" {
+  source  = "terraform-google-modules/iam/google//modules/iap_web_backend_services_iam"
+  version = "~> 8.1" // Specify the correct version
+
+  project                = "my-gcp-project-id"
+  web_backend_services = ["my-backend-service-one", "my-backend-service-two"]
+  mode                   = "additive"
+
+  bindings = {
+    "roles/iap.httpsResourceAccessor" = [
+      "serviceAccount:my-sa@my-gcp-project-id.iam.gserviceaccount.com",
+      "group:my-group@example.com",
+      "user:my-user@example.com",
+    ]
+  }
+
+  conditional_bindings = [
+    {
+      role        = "roles/iap.httpsResourceAccessor"
+      title       = "expires_after_2024_12_31"
+      description = "Expiring at midnight of 2024-12-31"
+      expression  = "request.time < timestamp(\"2025-01-01T00:00:00Z\")"
+      members     = ["user:limited-user@example.com"]
+    }
+  ]
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| bindings | Map of role (key) and list of members (value) to add the IAM policies/bindings. | `map(list(string))` | `{}` | no |
+| conditional\_bindings | List of maps of role, condition, and members to add the IAM policies/bindings. | <pre>list(object({<br>    role        = string<br>    title       = string<br>    description = optional(string)<br>    expression  = string<br>    members     = list(string)<br>  }))</pre> | `[]` | no |
+| mode | Mode for adding IAM policies/bindings. Valid values are 'additive' or 'authoritative'. | `string` | `"additive"` | no |
+| project | Project ID where the IAP Web Backend Services are located. | `string` | `null` | no |
+| web\_backend\_services | List of IAP Web Backend Service names to add IAM policies/bindings to. | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| members | Members who were bound to the IAP Web Backend Services. |
+| roles | Roles which were assigned to members. |
+| web\_backend\_services | IAP Web Backend Services which received bindings. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iap_web_backend_services_iam/main.tf
+++ b/modules/iap_web_backend_services_iam/main.tf
@@ -1,0 +1,53 @@
+/******************************************
+  Run helper module to get generic calculated data
+ *****************************************/
+module "helper" {
+  source               = "../helper"
+  bindings             = var.bindings
+  mode                 = var.mode
+  entities             = var.web_backend_services
+  conditional_bindings = var.conditional_bindings
+}
+
+
+/******************************************
+  IAP Web Backend IAM binding authoritative
+ *****************************************/
+resource "google_iap_web_backend_service_iam_binding" "iap_web_backend_service_iam_authoritative" {
+  for_each = module.helper.set_authoritative
+
+  project             = var.project
+  web_backend_service = module.helper.bindings_authoritative[each.key].name
+  role                = module.helper.bindings_authoritative[each.key].role
+  members             = module.helper.bindings_authoritative[each.key].members
+
+  dynamic "condition" {
+    for_each = module.helper.bindings_authoritative[each.key].condition.title == "" ? [] : [module.helper.bindings_authoritative[each.key].condition]
+    content {
+      title       = condition.value.title
+      description = condition.value.description
+      expression  = condition.value.expression
+    }
+  }
+}
+
+/******************************************
+  IAP Web Backend IAM binding additive
+ *****************************************/
+resource "google_iap_web_backend_service_iam_member" "iap_web_backend_service_iam_additive" {
+  for_each = module.helper.set_additive
+
+  project             = var.project
+  web_backend_service = module.helper.bindings_additive[each.key].name
+  role                = module.helper.bindings_additive[each.key].role
+  member              = module.helper.bindings_additive[each.key].member
+
+  dynamic "condition" {
+    for_each = module.helper.bindings_additive[each.key].condition.title == "" ? [] : [module.helper.bindings_additive[each.key].condition]
+    content {
+      title       = condition.value.title
+      description = condition.value.description
+      expression  = condition.value.expression
+    }
+  }
+}

--- a/modules/iap_web_backend_services_iam/outputs.tf
+++ b/modules/iap_web_backend_services_iam/outputs.tf
@@ -1,0 +1,26 @@
+output "web_backend_services" {
+  value       = distinct(module.helper.bindings_by_member[*].name)
+  description = "IAP Web Backend Services which received bindings."
+  depends_on = [
+    google_iap_web_backend_service_iam_binding.iap_web_backend_service_iam_authoritative,
+    google_iap_web_backend_service_iam_member.iap_web_backend_service_iam_additive
+  ]
+}
+
+output "roles" {
+  value       = distinct(module.helper.bindings_by_member[*].role)
+  description = "Roles which were assigned to members."
+  depends_on = [
+    google_iap_web_backend_service_iam_binding.iap_web_backend_service_iam_authoritative,
+    google_iap_web_backend_service_iam_member.iap_web_backend_service_iam_additive
+  ]
+}
+
+output "members" {
+  value       = distinct(module.helper.bindings_by_member[*].member)
+  description = "Members who were bound to the IAP Web Backend Services."
+  depends_on = [
+    google_iap_web_backend_service_iam_binding.iap_web_backend_service_iam_authoritative,
+    google_iap_web_backend_service_iam_member.iap_web_backend_service_iam_additive
+  ]
+}

--- a/modules/iap_web_backend_services_iam/variables.tf
+++ b/modules/iap_web_backend_services_iam/variables.tf
@@ -1,0 +1,40 @@
+variable "project" {
+  description = "Project ID where the IAP Web Backend Services are located."
+  type        = string
+  default     = null
+}
+
+variable "web_backend_services" {
+  description = "List of IAP Web Backend Service names to add IAM policies/bindings to."
+  type        = list(string)
+  default     = []
+}
+
+variable "mode" {
+  description = "Mode for adding IAM policies/bindings. Valid values are 'additive' or 'authoritative'."
+  type        = string
+  default     = "additive"
+
+  validation {
+    condition     = contains(["additive", "authoritative"], var.mode)
+    error_message = "Mode must be one of 'additive' or 'authoritative'."
+  }
+}
+
+variable "bindings" {
+  description = "Map of role (key) and list of members (value) to add the IAM policies/bindings."
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "conditional_bindings" {
+  description = "List of maps of role, condition, and members to add the IAM policies/bindings."
+  type = list(object({
+    role        = string
+    title       = string
+    description = optional(string)
+    expression  = string
+    members     = list(string)
+  }))
+  default = []
+}

--- a/modules/iap_web_backend_services_iam/versions.tf
+++ b/modules/iap_web_backend_services_iam/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.3"
+  required_providers {
+
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.53, < 7"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-iam:service_accounts_iam/v8.1.0"
+  }
+}


### PR DESCRIPTION
This change introduces a new submodule for managing IAM policies for IAP (Identity-Aware Proxy) Web Backend Services, along with a corresponding example.

The module has been tested and is in use. 

Key changes include:

- **New Module:** Added `modules/iap_web_backend_services_iam` to allow management of IAM bindings for IAP-protected web backend services. This module follows the established pattern of other IAM submodules, supporting additive and authoritative modes,
as well as conditional bindings.
- **New Example:** Added `examples/iap_web_backend_service` to demonstrate the usage of the new `iap_web_backend_services_iam` module. The example shows how to apply both additive and authoritative IAM policies to specified backend services.
- **Documentation Updates:**
    - Updated the main `README.md` to include the new `iap_web_backend_services_iam` module in the list of submodules and the "IAM Bindings" section.
    - Added permissions guidance for IAP Web Backend Services in the main `README.md`.
    - Standardized the formatting of roles and permissions in the main `README.md`.
    - Added a `README.md` for the new module and the new example, including input/output documentation.
- **Example Refactor:** The `examples/iap_web_backend_service` was updated to use input variables for existing backend service names rather than creating new backend service resources within the example.

