### PR TITLE
Feature/issue 255 cloud run job submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is a collection of submodules that make it easier to non-destructively mana
 * [BigQuery IAM](modules/bigquery_datasets_iam)
 * [Billing Accounts IAM](modules/billing_accounts_iam)
 * [Cloud Run Service IAM](modules/cloud_run_services_iam)
+* [Cloud Run Job IAM](modules/cloud_run_v2_jobs_iam)
 * [Custom Role IAM](modules/custom_role_iam)
 * [DNS Zone IAM](modules/dns_zones_iam)
 * [Folders IAM](modules/folders_iam)

--- a/examples/cloud_run_job/README.md
+++ b/examples/cloud_run_job/README.md
@@ -1,0 +1,22 @@
+# Cloud Run Job Example
+
+This example illustrates how to use the `cloud_run_v2_jobs_iam` submodule
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| cloud\_run\_job\_one | First cloud run job to add the IAM policies/bindings | `string` | n/a | yes |
+| cloud\_run\_job\_two | Second cloud run job to add the IAM policies/bindings | `string` | n/a | yes |
+| group\_email | Email for group to receive roles (ex. group@example.com) | `string` | n/a | yes |
+| location | The location of the cloud run job | `string` | n/a | yes |
+| project | Project id of the cloud run job | `string` | n/a | yes |
+| sa\_email | Email for Service Account to receive roles (Ex. default-sa@example-project-id.iam.gserviceaccount.com) | `string` | n/a | yes |
+| user\_email | Email for group to receive roles (Ex. user@example.com) | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/cloud_run_job/main.tf
+++ b/examples/cloud_run_job/main.tf
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/******************************************
+  Module cloud_run_v2_jobs_iam calling
+ *****************************************/
+
+module "cloud_run_v2_jobs_iam" {
+  source  = "terraform-google-modules/iam/google//modules/cloud_run_v2_jobs_iam"
+  version = "~> 8.0"
+
+  project        = var.project
+  location       = var.location
+  cloud_run_jobs = [var.cloud_run_job_one, var.cloud_run_job_two]
+  mode           = "authoritative"
+
+  bindings = {
+    "roles/run.invoker" = [
+      "serviceAccount:${var.sa_email}",
+      "group:${var.group_email}",
+      "user:${var.user_email}",
+    ]
+    "roles/run.viewer" = [
+      "serviceAccount:${var.sa_email}",
+      "group:${var.group_email}",
+      "user:${var.user_email}",
+    ]
+  }
+}

--- a/examples/cloud_run_job/outputs.tf
+++ b/examples/cloud_run_job/outputs.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "cloud_run_jobs" {
+  value       = module.cloud_run_v2_jobs_iam.cloud_run_jobs
+  description = "Cloud Run jobs which received for bindings."
+}

--- a/examples/cloud_run_job/variables.tf
+++ b/examples/cloud_run_job/variables.tf
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "group_email" {
+  type        = string
+  description = "Email for group to receive roles (ex. group@example.com)"
+}
+
+variable "sa_email" {
+  type        = string
+  description = "Email for Service Account to receive roles (Ex. default-sa@example-project-id.iam.gserviceaccount.com)"
+}
+
+variable "user_email" {
+  type        = string
+  description = "Email for group to receive roles (Ex. user@example.com)"
+}
+
+/******************************************
+  cloud_run_v2_jobs_iam variables
+ *****************************************/
+variable "project" {
+  type        = string
+  description = "Project id of the cloud run job"
+}
+
+variable "location" {
+  type        = string
+  description = "The location of the cloud run job"
+}
+
+variable "cloud_run_job_one" {
+  type        = string
+  description = "First cloud run job to add the IAM policies/bindings"
+}
+
+variable "cloud_run_job_two" {
+  type        = string
+  description = "Second cloud run job to add the IAM policies/bindings"
+}

--- a/modules/cloud_run_v2_jobs_iam/README.md
+++ b/modules/cloud_run_v2_jobs_iam/README.md
@@ -1,0 +1,44 @@
+# Cloud Run Job IAM
+
+This module manages IAM authentication for Cloud Run jobs.
+
+## Usage
+
+Basic usage of this module:
+
+```hcl
+module "cloud_run_v2_jobs_iam" {
+  source = "terraform-google-modules/iam/google//modules/cloud_run_v2_jobs_iam"
+
+  project = "my-project"
+  location = "us-central1"
+  cloud_run_jobs = ["my-job"]
+
+  bindings = {
+    "roles/run.invoker" = [
+      "user:user@example.com",
+    ]
+  }
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| bindings | Map of role (key) and list of members (value) to add the IAM policies/bindings | `map(any)` | n/a | yes |
+| cloud_run_jobs | Cloud Run jobs list to add the IAM policies/bindings | `list(string)` | `[]` | no |
+| location | The location of the cloud run job | `string` | `""` | no |
+| mode | Mode for adding the IAM policies/bindings, additive and authoritative | `string` | `"additive"` | no |
+| project | Project to add the IAM policies/bindings | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| cloud_run_jobs | Cloud Run jobs which received for bindings. |
+| members | Members which were bound to the Cloud Run jobs. |
+| roles | Roles which were assigned to members. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/cloud_run_v2_jobs_iam/main.tf
+++ b/modules/cloud_run_v2_jobs_iam/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloud_run_v2_jobs_iam/main.tf
+++ b/modules/cloud_run_v2_jobs_iam/main.tf
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/******************************************
+  Run helper module to get generic calculated data
+ *****************************************/
+module "helper" {
+  source   = "../helper"
+  bindings = var.bindings
+  mode     = var.mode
+  entities = var.cloud_run_jobs
+}
+
+/******************************************
+  Cloud Run Job IAM binding authoritative
+ *****************************************/
+resource "google_cloud_run_v2_job_iam_binding" "cloud_run_iam_authoritative" {
+  for_each = module.helper.set_authoritative
+  project  = var.project
+  location = var.location
+  name     = module.helper.bindings_authoritative[each.key].name
+  role     = module.helper.bindings_authoritative[each.key].role
+  members  = module.helper.bindings_authoritative[each.key].members
+}
+
+/******************************************
+   Cloud Run Job IAM binding additive
+ *****************************************/
+resource "google_cloud_run_v2_job_iam_member" "cloud_run_iam_additive" {
+  for_each = module.helper.set_additive
+  project  = var.project
+  location = var.location
+  name     = module.helper.bindings_additive[each.key].name
+  role     = module.helper.bindings_additive[each.key].role
+  member   = module.helper.bindings_additive[each.key].member
+}

--- a/modules/cloud_run_v2_jobs_iam/metadata.yaml
+++ b/modules/cloud_run_v2_jobs_iam/metadata.yaml
@@ -1,0 +1,115 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: terraform-google-iam
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  title: Module Cloud Run Job IAM
+  source:
+    repo: https://github.com/terraform-google-modules/terraform-google-iam/
+    sourceType: git
+  version: 8.2.0
+  actuationTool:
+    type: Terraform
+    version: '>= 0.13'
+  examples:
+  - name: cloud_run_job
+    location: examples/cloud_run_job
+  variables:
+  - name: bindings
+    description: Map of role (key) and list of members (value) to add the IAM policies/bindings
+    type: map(any)
+    required: true
+  - name: cloud_run_jobs
+    description: Cloud Run jobs list to add the IAM policies/bindings
+    type: list(string)
+    default: []
+    required: false
+  - name: location
+    description: The location of the cloud run job
+    type: string
+    default: ""
+    required: false
+  - name: mode
+    description: Mode for adding the IAM policies/bindings, additive and authoritative
+    type: string
+    default: additive
+    required: false
+  - name: project
+    description: Project to add the IAM policies/bindings
+    type: string
+    default: ""
+    required: false
+  outputs:
+  - name: cloud_run_jobs
+    description: Cloud Run jobs which received for bindings.
+  - name: members
+    description: Members which were bound to the Cloud Run jobs.
+  - name: roles
+    description: Roles which were assigned to members.
+  roles:
+  - level: Project
+    roles:
+    - roles/iam.organizationRoleAdmin
+    - roles/orgpolicy.policyAdmin
+    - roles/resourcemanager.organizationAdmin
+  - level: Project
+    roles:
+    - roles/owner
+    - roles/resourcemanager.projectIamAdmin
+    - roles/iam.serviceAccountAdmin
+    - roles/compute.admin
+    - roles/compute.networkAdmin
+    - roles/compute.storageAdmin
+    - roles/pubsub.admin
+    - roles/cloudkms.admin
+    - roles/storage.admin
+    - roles/composer.worker
+    - roles/secretmanager.admin
+  - level: Project
+    roles:
+    - roles/resourcemanager.projectCreator
+    - roles/resourcemanager.folderAdmin
+    - roles/resourcemanager.folderIamAdmin
+    - roles/owner
+    - roles/billing.projectManager
+    - roles/composer.worker
+  - level: Project
+    roles:
+    - roles/billing.user
+  - level: Project
+    roles:
+    - roles/billing.admin
+  services:
+  - admin.googleapis.com
+  - appengine.googleapis.com
+  - cloudbilling.googleapis.com
+  - cloudresourcemanager.googleapis.com
+  - compute.googleapis.com
+  - iam.googleapis.com
+  - iamcredentials.googleapis.com
+  - oslogin.googleapis.com
+  - serviceusage.googleapis.com
+  - cloudkms.googleapis.com
+  - pubsub.googleapis.com
+  - storage-api.googleapis.com
+  - servicenetworking.googleapis.com
+  - storage-component.googleapis.com
+  - iap.googleapis.com
+  - secretmanager.googleapis.com
+  - bigquery.googleapis.com

--- a/modules/cloud_run_v2_jobs_iam/outputs.tf
+++ b/modules/cloud_run_v2_jobs_iam/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloud_run_v2_jobs_iam/outputs.tf
+++ b/modules/cloud_run_v2_jobs_iam/outputs.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "cloud_run_jobs" {
+  value       = distinct(module.helper.bindings_by_member[*].name)
+  description = "Cloud Run jobs which received for bindings."
+  depends_on  = [google_cloud_run_v2_job_iam_binding.cloud_run_iam_authoritative, google_cloud_run_v2_job_iam_member.cloud_run_iam_additive]
+}
+
+output "roles" {
+  value       = distinct(module.helper.bindings_by_member[*].role)
+  description = "Roles which were assigned to members."
+}
+
+output "members" {
+  value       = distinct(module.helper.bindings_by_member[*].member)
+  description = "Members which were bound to the Cloud Run jobs."
+}

--- a/modules/cloud_run_v2_jobs_iam/variables.tf
+++ b/modules/cloud_run_v2_jobs_iam/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloud_run_v2_jobs_iam/variables.tf
+++ b/modules/cloud_run_v2_jobs_iam/variables.tf
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project" {
+  description = "Project to add the IAM policies/bindings"
+  default     = ""
+  type        = string
+}
+
+variable "location" {
+  description = "The location of the cloud run job"
+  default     = ""
+  type        = string
+}
+
+variable "cloud_run_jobs" {
+  description = "Cloud Run jobs list to add the IAM policies/bindings"
+  default     = []
+  type        = list(string)
+}
+
+variable "mode" {
+  description = "Mode for adding the IAM policies/bindings, additive and authoritative"
+  type        = string
+  default     = "additive"
+}
+
+variable "bindings" {
+  description = "Map of role (key) and list of members (value) to add the IAM policies/bindings"
+  type        = map(any)
+}

--- a/modules/cloud_run_v2_jobs_iam/versions.tf
+++ b/modules/cloud_run_v2_jobs_iam/versions.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/cloud_run_v2_jobs_iam/versions.tf
+++ b/modules/cloud_run_v2_jobs_iam/versions.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 1.3"
+  required_providers {
+
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.50, < 8"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-iam:cloud_run_v2_jobs_iam/v8.2.0"
+  }
+
+}

--- a/test/fixtures/additive/outputs.tf
+++ b/test/fixtures/additive/outputs.tf
@@ -137,3 +137,8 @@ output "secrets" {
   value       = module.generic.secrets
   description = "Secrets created for bindings."
 }
+
+output "cloud_run_jobs" {
+  value       = module.generic.cloud_run_jobs
+  description = "Cloud Run Jobs created for bindings."
+}

--- a/test/fixtures/authoritative/outputs.tf
+++ b/test/fixtures/authoritative/outputs.tf
@@ -142,3 +142,8 @@ output "secrets" {
   value       = module.generic.secrets
   description = "Secrets created for bindings."
 }
+
+output "cloud_run_jobs" {
+  value       = module.generic.cloud_run_jobs
+  description = "Cloud Run Jobs created for bindings."
+}

--- a/test/fixtures/helper/base/main.tf
+++ b/test/fixtures/helper/base/main.tf
@@ -65,7 +65,8 @@ resource "google_storage_bucket" "test" {
   project  = var.base_project_id
   location = local.location
 
-  name = "${local.prefix}-bkt-${count.index}-${random_id.test[count.index].hex}"
+  name                        = "${local.prefix}-bkt-${count.index}-${random_id.test[count.index].hex}"
+  uniform_bucket_level_access = true
 }
 
 # KMS
@@ -164,6 +165,7 @@ resource "google_tags_tag_key" "tag_key" {
   description = "test tag ${count.index}"
 }
 
+
 # Tag Key
 
 resource "google_tags_tag_value" "tag_value" {
@@ -171,4 +173,22 @@ resource "google_tags_tag_value" "tag_value" {
   parent      = "tagKeys/${google_tags_tag_key.tag_key[count.index].name}"
   short_name  = "${local.prefix}-tagvalue-${count.index}-${random_id.test[count.index].hex}"
   description = "test value ${count.index}"
+}
+
+# Cloud Run Job
+
+resource "google_cloud_run_v2_job" "test" {
+  count = local.n
+
+  name     = "${local.prefix}-job-${count.index}-${random_id.test[count.index].hex}"
+  location = local.location
+  project  = var.base_project_id
+
+  template {
+    template {
+      containers {
+        image = "us-docker.pkg.dev/cloudrun/container/hello"
+      }
+    }
+  }
 }

--- a/test/fixtures/helper/base/outputs.tf
+++ b/test/fixtures/helper/base/outputs.tf
@@ -96,3 +96,8 @@ output "tag_values" {
   value       = google_tags_tag_value.tag_value.*.name
   description = "Tag values created for bindings."
 }
+
+output "cloud_run_jobs" {
+  value       = google_cloud_run_v2_job.test.*.name
+  description = "Cloud Run Jobs created for bindings."
+}

--- a/test/fixtures/helper/iam.tf
+++ b/test/fixtures/helper/iam.tf
@@ -138,9 +138,19 @@ module "iam_binding_tag_keys" {
   bindings = local.basic_bindings
 }
 
+
 module "iam_binding_tag_values" {
   source     = "../../../modules/tag_values_iam"
   mode       = var.mode
   tag_values = module.base.tag_values
   bindings   = local.basic_bindings
+}
+
+module "iam_binding_cloud_run_job" {
+  source         = "../../../modules/cloud_run_v2_jobs_iam"
+  mode           = var.mode
+  cloud_run_jobs = module.base.cloud_run_jobs
+  project        = var.project_id
+  location       = module.base.region
+  bindings       = local.basic_bindings
 }

--- a/test/fixtures/helper/outputs.tf
+++ b/test/fixtures/helper/outputs.tf
@@ -136,3 +136,8 @@ output "secrets" {
   value       = module.base.secrets
   description = "Secrets created for bindings."
 }
+
+output "cloud_run_jobs" {
+  value       = module.base.cloud_run_jobs
+  description = "Cloud Run Jobs created for bindings."
+}

--- a/test/integration/additive/controls/additive.rb
+++ b/test/integration/additive/controls/additive.rb
@@ -31,6 +31,7 @@ topics           = attribute('topics')
 subscriptions    = attribute('subscriptions')
 region           = attribute('region')
 secrets          = attribute('secrets')
+cloud_run_jobs   = attribute('cloud_run_jobs')
 
 # Role pairs (arrays of length = 2)
 basic_roles               = attribute('basic_roles')
@@ -297,6 +298,30 @@ control 'secret-bindings' do
   title 'Test secret manager bindings are correct'
 
   describe secrets.map { |secret| secret_bindings(secret, project_id) } do
+    it 'include the 1st binding' do
+      if roles < 1
+        skip 'less than 1 roles specified'
+      else
+        should all include role: basic_roles[0], members: member_groups[0]
+      end
+    end
+
+    it 'include the 2st binding' do
+      if roles < 2
+        skip 'less than 2 roles specified'
+      else
+        should all include role: basic_roles[1], members: member_groups[1]
+      end
+    end
+  end
+end
+
+# Cloud Run Jobs
+
+control 'cloud-run-job-bindings' do
+  title 'Test cloud run job bindings are correct'
+
+  describe cloud_run_jobs.map { |job| cloud_run_job_bindings(job, project_id, region) } do
     it 'include the 1st binding' do
       if roles < 1
         skip 'less than 1 roles specified'

--- a/test/integration/authoritative/controls/authoritative.rb
+++ b/test/integration/authoritative/controls/authoritative.rb
@@ -32,6 +32,7 @@ subscriptions    = attribute('subscriptions')
 region           = attribute('region')
 audit_config     = attribute('audit_config')
 secrets          = attribute('secrets')
+cloud_run_jobs   = attribute('cloud_run_jobs')
 
 # Role pairs (arrays of length = 2)
 basic_roles               = attribute('basic_roles')
@@ -342,6 +343,30 @@ control 'secret-bindings' do
   title 'Test secret manager bindings are correct'
 
   describe secrets.map { |secret| secret_bindings(secret, project_id) } do
+    it 'include the 1st binding' do
+      if roles < 1
+        skip 'less than 1 roles specified'
+      else
+        should all include role: basic_roles[0], members: member_groups[0]
+      end
+    end
+
+    it 'include the 2st binding' do
+      if roles < 2
+        skip 'less than 2 roles specified'
+      else
+        should all include role: basic_roles[1], members: member_groups[1]
+      end
+    end
+  end
+end
+
+# Cloud Run Jobs
+
+control 'cloud-run-job-bindings' do
+  title 'Test cloud run job bindings are correct'
+
+  describe cloud_run_jobs.map { |job| cloud_run_job_bindings(job, project_id, region) } do
     it 'include the 1st binding' do
       if roles < 1
         skip 'less than 1 roles specified'

--- a/test/integration/helper/libraries/bindings.rb
+++ b/test/integration/helper/libraries/bindings.rb
@@ -160,3 +160,13 @@ class SecretManager < Bindings
     "gcloud beta secrets get-iam-policy #{secret} --project='#{project}' --format='json(bindings)'"
   end
 end
+
+# Cloud Run Jobs
+
+class CloudRunJobBindings < Bindings
+  name 'cloud_run_job_bindings'
+  private
+  def get_command(job, project, region)
+    "gcloud run jobs get-iam-policy #{job} --project='#{project}' --region='#{region}' --format='json(bindings)'"
+  end
+end

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -21,8 +21,9 @@ resource "random_id" "folder-rand" {
 }
 
 resource "google_folder" "ci-iam-folder" {
-  display_name = "ci-tests-iam-folder-${random_id.folder-rand.hex}"
-  parent       = "folders/${var.folder_id}"
+  display_name        = "ci-tests-iam-folder-${random_id.folder-rand.hex}"
+  parent              = "folders/${var.folder_id}"
+  deletion_protection = false
 }
 
 module "iam-project" {
@@ -35,6 +36,7 @@ module "iam-project" {
   folder_id           = var.folder_id
   billing_account     = var.billing_account
   auto_create_network = true
+  deletion_policy     = "DELETE"
 
   activate_apis = [
     "admin.googleapis.com",
@@ -48,6 +50,7 @@ module "iam-project" {
     "serviceusage.googleapis.com",
     "cloudkms.googleapis.com",
     "pubsub.googleapis.com",
+    "run.googleapis.com",
     "storage-api.googleapis.com",
     "servicenetworking.googleapis.com",
     "storage-component.googleapis.com",


### PR DESCRIPTION
## Title

feat: add Cloud Run v2 Jobs IAM submodule

## Description

Closes #255

Adds a `cloud_run_v2_jobs_iam` submodule for managing IAM bindings on Cloud Run v2 Jobs.

### Changes

- Adds additive and authoritative IAM support through:
  - `google_cloud_run_v2_job_iam_member`
  - `google_cloud_run_v2_job_iam_binding`
- Uses the shared IAM helper module and exposes standard `cloud_run_jobs`, `roles`, and `members` outputs.
- Adds module documentation and a Cloud Run Job example.
- Adds additive and authoritative integration-test coverage.
- Enables `run.googleapis.com` in the isolated integration-test project.
- Makes test fixtures compatible with organization policies requiring Uniform Bucket-Level Access.
- Configures the isolated test project and folder for explicit cleanup.
- Sets the Google provider minimum version to `4.50`, the first release supporting Cloud Run v2 Job IAM resources.

### Validation

- `terraform fmt -check`
- Applied the additive fixture in GCP.
- Verified the live IAM policy for the test Cloud Run Job:
  - `roles/editor` assigned to the expected service account.
  - `roles/owner` assigned to both expected service accounts.